### PR TITLE
Restructure skill for progressive disclosure

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -13,6 +13,59 @@ description: >-
 You have MCP access to a running marimo notebook. This document defines how to
 use it as a thoughtful collaborator.
 
+## Two Modes of Working
+
+`execute_code` is your only way to interact with the notebook. It serves two
+distinct purposes:
+
+**Scratchpad** (simple): Just Python — `print(df.head())`, check data shapes,
+test a snippet. The notebook's cell variables are already in scope. Results
+come back to you — the user doesn't see them. Use this freely.
+
+Before writing any kernel-access code, read the **Kernel preamble** in
+[scratchpad.md](reference/scratchpad.md) for the correct entry point and imports.
+
+**Cell operations** (complex): Creating, editing, moving, deleting cells.
+These require careful API orchestration — compile, register, notify the
+frontend, then execute. Get it wrong and the UI desyncs.
+
+## Decision Tree
+
+| Situation | Action |
+|-----------|--------|
+| Need to read data/state | Use recipes in [scratchpad.md](reference/scratchpad.md) |
+| Need to create/edit/move/delete cells | Follow the scratchpad-to-cell workflow below, then use [cell-operations.md](reference/cell-operations.md) |
+| Unsure what API to use | See **Discovering the API** in [kernel-api.md](reference/kernel-api.md) |
+| Import path fails | See **Discovering the API** in [kernel-api.md](reference/kernel-api.md) |
+| Want a full walkthrough | Read [worked-example.md](reference/worked-example.md) |
+
+## The Scratchpad-to-Cell Workflow
+
+Before adding or editing a cell, always validate in the scratchpad first.
+Compiling and graph-checking are cheap — always do them. Running code catches
+real bugs before the user sees them.
+
+### Adding a new cell
+
+1. **Write** your code as a string
+2. **Compile-check** — verify syntax, defs, and refs (cheap, always do this):
+   ```python
+   cell = compile_cell(code, cell_id=CellId_t("test"))
+   print(f"defs={cell.defs}, refs={cell.refs}")
+   ```
+   See `compile-check` in [scratchpad.md](reference/scratchpad.md) for full recipe.
+3. **Test in scratchpad** — run the code via `execute_code` to confirm it works. If it's expensive (network request, large query), test on a subset (smaller input, LIMIT clause, fewer params)
+4. **If the code contains a network request or query**: consider asking the user before creating the cell, since execution will happen again when the cell runs. Or structure as two cells (fetch + transform) so the fetch only runs once
+5. **Create the cell** — follow `create-cell` in [cell-operations.md](reference/cell-operations.md)
+
+### Editing an existing cell
+
+1. **Read** the current cell code from the graph
+2. **Write** the modified code as a string
+3. **Compile-check** — verify the edit doesn't break defs/refs or create cycles
+4. **Test in scratchpad** — run the modified code to confirm it works
+5. **Update the cell** — follow `edit-cell` in [cell-operations.md](reference/cell-operations.md)
+
 ## Philosophy
 
 **You are a collaborator, not a code generator.** You're sitting next to someone
@@ -21,82 +74,8 @@ ideas — but it's *their* notebook.
 
 1. **The notebook is the artifact.** Build it *with* the user, not *for* them.
 2. **User steers, you navigate.** They're the domain expert. You handle code.
-3. **Turn-based, not batch.** One step at a time. Present. Wait for input.
-4. **Show your work.** Cells are checkpoints — comments, markdown, alerts.
-5. **Be present.** Create and focus your working cell before any scratchpad work.
-
-## Decision Tree
-
-| Situation | Action |
-|-----------|--------|
-| Starting a new task | Follow **Starting a Task** workflow below |
-| Continuing multi-step work | Follow **Turn-Based Working Pattern** |
-| Need to read data/state | Use Tier 1 recipes in [kernel-api.md](reference/kernel-api.md) |
-| Need to create/run a cell | Use Tier 4 recipes — always format after writing |
-| Need to restructure cells | Use Tier 5 recipes — **ask user first** |
-| Unsure what API to use | Use **Discovering the API** section in [kernel-api.md](reference/kernel-api.md) |
-| First time seeing the workflow | Read [worked-example.md](reference/worked-example.md) |
-
----
-
-## Starting a Task
-
-1. **Understand** — ask what they're trying to accomplish, not just what they asked for
-2. **Show up** — create a working cell and focus it before any investigation:
-   ```python
-   # [Agent work]
-   # Investigating your data — checking variables, shapes, and imports...
-   ```
-3. **Orient** — investigate via scratchpad, logging every probe to the cell immediately
-4. **Propose** — suggest an approach (libraries, app vs analysis mode, scope)
-5. **Agree** — get buy-in before writing code
-
-## Turn-Based Working Pattern
-
-```
-Show Up → Observe → Plan → Checkpoint → Execute → Present → Wait
-```
-
-- **Show Up**: Create/update a working cell. User must see you arrive first.
-- **Observe**: Read cell state, variables, data shapes. Use Tier 1 recipes.
-- **Plan**: Describe one step in chat.
-- **Checkpoint**: Probe in scratchpad. Log each probe to the cell immediately.
-- **Execute**: Run the cell. Always format with ruff after writing.
-- **Present**: Focus the cell, send an alert, or describe the output.
-- **Wait**: Stop. Ask what the user thinks. Never proceed without input.
-
-## Working Cell
-
-Each step gets **one cell**. Your work log lives as comments at the top of the
-code cell you're building.
-
-CRITICAL: Create and focus the cell BEFORE doing any scratchpad work. The user
-must see you arrive in the notebook before you start investigating.
-
-Sequence: create cell → focus it → run probe → update cell → repeat → add draft code.
-
-### Probe log format
-
-```python
-# task: <what we're checking>
-#
-# ```py
-# <the code we ran>
-# ```
-#
-# summary: <one-line result>
-# ---
-```
-
-Log each probe immediately after it runs — never batch them. After all probes:
-
-```python
-# Draft code:
-
-<actual python code>
-```
-
-For a full walkthrough, see [worked-example.md](reference/worked-example.md).
+3. **Balance visibility.** For a clear, specific ask — just do it. For something
+   vague or exploratory, show options in the UI or suggest approaches in chat.
 
 ## App vs Analysis Mode
 
@@ -109,30 +88,29 @@ Ask early — this shapes how you build cells.
 
 ## Guard Rails
 
-CRITICAL: Create and focus a working cell BEFORE any `execute_code` call. This
-is the #1 rule.
+NEVER: Reload, restart, shutdown, or save the notebook — these are user-only.
 
-NEVER: Reload, restart, shutdown, or save the notebook. These are Tier 6 — user
-only.
+NEVER: Write to the notebook `.py` file — no `Edit`, `Write`, `sed`, or any
+file-modification tool. The kernel owns the file; writing behind its back will
+desync state. You MAY read it (via `Read`, `Grep`, etc.) to understand existing
+code and structure.
 
-NEVER: Install packages without confirming with the user first. Always use
-`InstallPackagesCommand` to install packages.
+NEVER: Install packages without confirming with the user first.
 
 NEVER: Delete user cells without confirmation.
 
-NEVER: Create more than one cell per turn without asking.
+NEVER: Create more than one cell at a time without asking.
 
 NEVER: Modify existing user code without proposing the change first.
 
-IMPORTANT: Always format cell code with ruff after writing. See the `format-cell`
-recipe in [kernel-api.md](reference/kernel-api.md).
+IMPORTANT: When creating or updating a cell, notify the frontend BEFORE
+executing. See the `create-cell` and `edit-cell` recipes.
+
+IMPORTANT: Always format cell code with ruff after writing. See `format-cell`
+in [cell-operations.md](reference/cell-operations.md).
 
 IMPORTANT: The scratchpad shares the kernel's namespace — side effects persist.
 Clean up dry-run registrations (`graph.delete_cell`) to avoid phantom cells.
 
 IMPORTANT: `code_is_stale=True` means the frontend shows code but the kernel
 hasn't run it — use this for drafts the user should review before execution.
-
-## API Reference
-
-See [reference/kernel-api.md](reference/kernel-api.md) for tiered recipes.

--- a/reference/cell-operations.md
+++ b/reference/cell-operations.md
@@ -1,0 +1,160 @@
+# Cell Operations Reference
+
+Recipes for creating, editing, moving, and deleting cells. These require careful
+orchestration — compile, register, notify the frontend, then execute. Get the
+order wrong and the UI desyncs.
+
+## Contents
+
+- [create-cell](#create-cell) — compile, register, notify, execute
+- [edit-cell](#edit-cell) — update code (draft or immediate)
+- [move-cell](#move-cell) — reorder cells
+- [delete-cell](#delete-cell) — remove a cell
+- [format-cell](#format-cell) — format with ruff (always do this)
+- [install-packages](#install-packages) — add dependencies
+- [cell-config](#cell-config) — hide_code, disabled, etc.
+- [run-stale](#run-stale) — execute all stale cells
+- [notify-user](#notify-user) — toast, banner, focus
+
+## Preamble
+
+```python
+from marimo._runtime.context import get_context
+from marimo._ast.compiler import compile_cell
+from marimo._types.ids import CellId_t
+from marimo._runtime.commands import ExecuteCellCommand
+from marimo._messaging.notification import (
+    UpdateCellIdsNotification,
+    UpdateCellCodesNotification,
+)
+from marimo._messaging.serde import serialize_kernel_message
+
+kernel = get_context()._kernel
+graph = kernel.graph
+stream = kernel.stream
+
+def notify(n):
+    stream.write(serialize_kernel_message(n))
+```
+
+## create-cell
+
+Every step matters — skipping one breaks the UI.
+
+```python
+cell_id = CellId_t("my_cell")
+cell = compile_cell(code, cell_id=cell_id)
+graph.register_cell(cell_id, cell)
+
+# 1. Notify frontend about the new cell and its code
+notify(UpdateCellIdsNotification(cell_ids=list(graph.cells.keys())))
+notify(UpdateCellCodesNotification(cell_ids=[cell_id], codes=[code], code_is_stale=False))
+
+# 2. Execute AFTER notifying
+await kernel.run([ExecuteCellCommand(cell_id=cell_id, code=code)])
+```
+
+## edit-cell
+
+**As a draft** (user reviews before execution):
+
+```python
+notify(UpdateCellCodesNotification(cell_ids=[cell_id], codes=[new_code], code_is_stale=True))
+```
+
+**Update and execute immediately:**
+
+```python
+graph.delete_cell(cell_id)  # must delete before re-registering
+cell = compile_cell(new_code, cell_id=cell_id)
+graph.register_cell(cell_id, cell)
+notify(UpdateCellCodesNotification(cell_ids=[cell_id], codes=[new_code], code_is_stale=False))
+await kernel.run([ExecuteCellCommand(cell_id=cell_id, code=new_code)])
+```
+
+## move-cell
+
+```python
+ids = list(graph.cells.keys())
+ids.remove(cell_id)
+ids.insert(0, cell_id)  # move to top
+notify(UpdateCellIdsNotification(cell_ids=ids))
+```
+
+## delete-cell
+
+```python
+graph.delete_cell(cell_id)
+notify(UpdateCellIdsNotification(cell_ids=list(graph.cells.keys())))
+```
+
+## format-cell
+
+Always format after writing code.
+
+```python
+from marimo._utils.formatter import DefaultFormatter
+
+formatter = DefaultFormatter(line_length=79)
+formatted = await formatter.format({cell_id: code})
+notify(UpdateCellCodesNotification(cell_ids=[cell_id], codes=[formatted[cell_id]], code_is_stale=False))
+```
+
+## install-packages
+
+Always confirm with the user before installing.
+
+```python
+from marimo._runtime.commands import InstallPackagesCommand
+
+await kernel.run([
+    InstallPackagesCommand(
+        manager=kernel.user_config["package_management"]["manager"],
+        versions={"scikit-learn": "", "pandas": ">=2.0"},
+    )
+])
+```
+
+## cell-config
+
+```python
+from marimo._runtime.commands import UpdateCellConfigCommand
+
+await kernel.run([UpdateCellConfigCommand(configs={cell_id: {"disabled": True}})])
+```
+
+## run-stale
+
+```python
+from marimo._runtime.commands import ExecuteStaleCellsCommand
+
+await kernel.run([ExecuteStaleCellsCommand()])
+```
+
+## notify-user
+
+```python
+from marimo._messaging.notification import (
+    AlertNotification,
+    BannerNotification,
+    FocusCellNotification,
+)
+
+# Toast notification
+notify(AlertNotification(title="Done", description="Found 3 outliers", variant=None))
+
+# Persistent banner
+notify(BannerNotification(title="Packages needed", description="Install scikit-learn?", variant=None, action=None))
+
+# Focus a cell
+notify(FocusCellNotification(cell_id=cell_id))
+```
+
+`variant`: `None` (info) or `"danger"` (error). Banner `action`: `None` or `"restart"`.
+
+## Don'ts
+
+- **Don't skip `await`** — `kernel.run()` returns a coroutine
+- **Don't send `CellNotification` with empty output after `kernel.run()`** — it clobbers real output
+- **Don't skip notifications before execute** — the kernel runs but the UI won't show the cell
+- **Don't skip formatting** — always run ruff after writing code

--- a/reference/kernel-api.md
+++ b/reference/kernel-api.md
@@ -1,78 +1,18 @@
 # marimo Kernel API Reference
 
-Risk-tiered recipes for the `execute_code` scratchpad. Each recipe is
-**self-contained** — include all imports and setup inline since `execute_code`
-runs in a fresh scope every time (only kernel globals from notebook cells
-persist between calls).
+Entry point for API details. Recipes are split into focused files:
 
-## Preambles
+- [scratchpad.md](scratchpad.md) — scratchpad inspection recipes
+- [cell-operations.md](cell-operations.md) — cell mutation recipes
 
-Use the **minimal preamble** for read-only work (Tiers 1–2). Only pull in the
-full cell-mutation imports when you actually need to create, update, or delete
-cells (Tiers 3–5).
-
-### Minimal preamble (read-only — Tiers 1–2)
-
-```python
-from marimo._runtime.context import get_context
-
-kernel = get_context()._kernel
-graph = kernel.graph
-```
-
-This is all you need to inspect cells, variables, graph health, etc.
-
-### Cell-mutation preamble (Tiers 3–5)
-
-```python
-from marimo._runtime.context import get_context
-from marimo._ast.compiler import compile_cell
-from marimo._types.ids import CellId_t
-from marimo._runtime.commands import ExecuteCellCommand
-from marimo._messaging.notification import (
-    UpdateCellIdsNotification,
-    UpdateCellCodesNotification,
-    CellNotification,
-    FocusCellNotification,
-)
-from marimo._messaging.cell_output import CellOutput, CellChannel
-from marimo._messaging.serde import serialize_kernel_message
-
-kernel = get_context()._kernel
-graph = kernel.graph
-stream = kernel.stream
-
-def notify(n):
-    stream.write(serialize_kernel_message(n))
-```
-
-### Additional imports (use only when needed)
-
-```python
-# Additional commands
-from marimo._runtime.commands import (
-    UpdateCellConfigCommand,
-    ExecuteStaleCellsCommand,
-    InstallPackagesCommand,
-)
-
-# Additional notifications
-from marimo._messaging.notification import (
-    AlertNotification,
-    BannerNotification,
-)
-
-# Formatting
-from marimo._utils.formatter import DefaultFormatter
-```
-
-Known-good paths as of marimo 0.20.4. If an import fails, use the
-"Discovering the API" section to find the correct path for your version.
+Each reference file includes its own preamble with the imports you need.
+Use the minimal preamble for scratchpad work; only pull in the full
+cell-mutation imports when you need to create, update, or delete cells.
 
 ## Discovering the API
 
-If an import fails or you need something not listed above, explore from
-within `execute_code`:
+If an import fails or you need something not listed in the reference files,
+explore from within `execute_code`:
 
 ```python
 import marimo
@@ -89,139 +29,3 @@ print([n for n in dir(notification) if n.endswith("Notification")])
 ```
 
 Use this to verify import paths and discover new APIs rather than guessing.
-
----
-
-## Tier 1: Observe (read-only)
-
-```python
-# List cells with defs, refs, code
-for cid, cell in graph.cells.items():
-    print(cid, cell.defs, cell.refs, cell.code[:80])
-
-# Cell status
-for cid, cell in graph.cells.items():
-    print(cid, cell._status.state, f"stale={cell._stale.state}")
-
-# Graph health
-graph.get_multiply_defined()          # name conflicts
-graph.cycles                          # cell IDs in cycles
-graph.get_stale()                     # all stale cell IDs
-
-# Inspect variables
-for name, val in kernel.globals.items():
-    print(name, type(val).__name__, getattr(val, 'shape', ''))
-```
-
-**Don't:** Use `.state` or `.is_running` — status is on `._status.state`.
-
----
-
-## Tier 2: Validate (read-only)
-
-```python
-# Compile-check (syntax + defs/refs, no execution)
-cell = compile_cell(code, cell_id=CellId_t("test"))
-print(f"defs={cell.defs}, refs={cell.refs}")
-
-# Dry-run registration (always clean up afterward)
-cell_id = CellId_t("dry_run")
-cell = compile_cell(code, cell_id=cell_id)
-graph.register_cell(cell_id, cell)
-print(graph.get_multiply_defined(), graph.cycles)
-graph.delete_cell(cell_id)  # ALWAYS clean up
-```
-
----
-
-## Tier 3: Communicate (non-destructive)
-
-```python
-# Toast notification
-notify(AlertNotification(title="Done", description="Found 3 outliers", variant=None))
-
-# Persistent banner
-notify(BannerNotification(title="Packages needed", description="Install scikit-learn?", variant=None, action=None))
-
-# Focus a cell
-notify(FocusCellNotification(cell_id=cell_id))
-```
-
-`variant`: `None` (info) or `"danger"` (error). Banner `action`: `None` or `"restart"`.
-
----
-
-## Tier 4: Modify (medium risk, reversible)
-
-### Create & execute a cell
-
-```python
-cell_id = CellId_t("my_cell")
-cell = compile_cell(code, cell_id=cell_id)
-graph.register_cell(cell_id, cell)
-await kernel.run([ExecuteCellCommand(cell_id=cell_id, code=code)])
-
-# All 3 notifications required for UI to update
-notify(UpdateCellIdsNotification(cell_ids=list(graph.cells.keys())))
-notify(UpdateCellCodesNotification(cell_ids=[cell_id], codes=[code], code_is_stale=False))
-notify(CellNotification(cell_id=cell_id, output=CellOutput(channel=CellChannel.OUTPUT, mimetype="text/plain", data=""), status="idle"))
-```
-
-**Don't:** Skip `await` — `kernel.run()` returns a coroutine.
-**Don't:** Skip the 3 `notify()` calls — kernel works but UI shows nothing.
-
-### Other Tier 4 operations
-
-```python
-# Update cell config (disabled, hide_code, column)
-await kernel.run([UpdateCellConfigCommand(configs={cell_id: {"disabled": True}})])
-
-# Execute all stale cells
-await kernel.run([ExecuteStaleCellsCommand()])
-```
-
----
-
-## Tier 5: Restructure (high risk — confirm with user)
-
-```python
-# Move cell (reorder by sending full ID list)
-ids = list(graph.cells.keys())
-ids.remove(cell_id)
-ids.insert(0, cell_id)
-notify(UpdateCellIdsNotification(cell_ids=ids))
-
-# Delete cell
-graph.delete_cell(cell_id)
-notify(UpdateCellIdsNotification(cell_ids=list(graph.cells.keys())))
-
-# Update cell code (code_is_stale=True for drafts, False if already executed)
-notify(UpdateCellCodesNotification(cell_ids=[cell_id], codes=[new_code], code_is_stale=True))
-
-# Format cell with ruff
-formatter = DefaultFormatter(line_length=79)
-formatted = await formatter.format({cell_id: code})
-notify(UpdateCellCodesNotification(cell_ids=[cell_id], codes=[formatted[cell_id]], code_is_stale=False))
-
-```
-
-### Install packages
-
-Always confirm with the user before installing. Requires `InstallPackagesCommand`
-from the additional imports.
-
-```python
-# versions: empty string for latest, or a version constraint
-await kernel.run([
-    InstallPackagesCommand(
-        manager=kernel.user_config["package_management"]["manager"],
-        versions={"scikit-learn": "", "pandas": ">=2.0"},
-    )
-])
-```
-
----
-
-## Tier 6: Dangerous (never agent-initiated)
-
-Reload, restart, shutdown, save — **never** trigger these without explicit user request. Confirm and explain what will be lost.

--- a/reference/scratchpad.md
+++ b/reference/scratchpad.md
@@ -1,0 +1,93 @@
+# Scratchpad Reference
+
+Recipes for using `execute_code` to inspect notebook state. Results come back
+to you — the user doesn't see them.
+
+The scratchpad is just Python. You can `print(df.head())` or run any expression
+directly — the notebook's cell variables are already in scope. The preamble
+below is only needed when you want to inspect kernel internals (graph structure,
+cell metadata, defs/refs).
+
+**Scoping:** Variables defined in the scratchpad do not persist between
+`execute_code` calls. Only notebook cell variables survive. Do all dependent
+work in a single call, and avoid polluting the kernel namespace.
+
+## Contents
+
+- [list-cells](#list-cells) — cell IDs, defs, refs, code
+- [cell-status](#cell-status) — running, stale, error states
+- [check-graph](#check-graph) — cycles, multiply-defined, stale cells
+- [inspect-variables](#inspect-variables) — kernel globals
+- [compile-check](#compile-check) — syntax + defs/refs without execution
+- [dry-run](#dry-run) — register and check graph impact, then clean up
+
+## Kernel preamble
+
+Only needed for the recipes below that access `kernel` or `graph`:
+
+```python
+from marimo._runtime.context import get_context
+
+kernel = get_context()._kernel
+graph = kernel.graph
+```
+
+## list-cells
+
+```python
+for cid, cell in graph.cells.items():
+    print(cid, cell.defs, cell.refs, cell.code[:80])
+```
+
+## cell-status
+
+```python
+for cid, cell in graph.cells.items():
+    print(cid, cell._status.state, f"stale={cell._stale.state}")
+```
+
+**Don't:** Use `.state` or `.is_running` directly — status is on `._status.state`.
+
+## check-graph
+
+```python
+graph.get_multiply_defined()   # name conflicts
+graph.cycles                   # cell IDs in cycles
+graph.get_stale()              # all stale cell IDs
+```
+
+## inspect-variables
+
+```python
+for name, val in kernel.globals.items():
+    print(name, type(val).__name__, getattr(val, 'shape', ''))
+```
+
+## compile-check
+
+Syntax + defs/refs validation without execution. Cheap — always do this before
+creating or editing a cell. `compile_cell` does not register the cell in the
+graph, so there is nothing to clean up afterward.
+
+```python
+from marimo._ast.compiler import compile_cell
+from marimo._types.ids import CellId_t
+
+cell = compile_cell(code, cell_id=CellId_t("test"))
+print(f"defs={cell.defs}, refs={cell.refs}")
+```
+
+## dry-run
+
+Register a cell in the graph to check for conflicts and cycles, then clean up.
+
+```python
+from marimo._ast.compiler import compile_cell
+from marimo._types.ids import CellId_t
+
+cell_id = CellId_t("dry_run")
+cell = compile_cell(code, cell_id=cell_id)
+graph.register_cell(cell_id, cell)
+print(graph.get_multiply_defined(), graph.cycles)
+graph.delete_cell(cell_id)  # ALWAYS clean up
+```

--- a/reference/worked-example.md
+++ b/reference/worked-example.md
@@ -1,109 +1,55 @@
 # Worked Example: "I want to plot this data"
 
-This walks through the full turn-based workflow from SKILL.md.
+This walks through the scratchpad-to-cell workflow from SKILL.md.
 
-## Step 1 — Show up first
+## Step 1 — Investigate via scratchpad
 
-Create and focus the cell before any investigation:
-
-```python
-# [Agent work]
-# Investigating your data — checking variables, shapes, and imports...
-```
-
-## Step 2 — Investigate via scratchpad
-
-Run `execute_code` to inspect variables. **Immediately** update the cell:
+Run `execute_code` calls to understand the notebook state. These are invisible
+to the user — just you gathering info. Cell variables are already in scope, so
+you can inspect them directly.
 
 ```python
-# [Agent work]
-#
-# task: inspect notebook variables
-#
-# ```py
-# for name, val in kernel.globals.items():
-#     print(name, type(val).__name__, getattr(val, 'shape', ''))
-# ```
-#
-# summary: found `sales` DataFrame (1200, 4)
-# ---
+# What variables exist?
+for name, val in vars().items():
+    if not name.startswith('_'):
+        print(name, type(val).__name__, getattr(val, 'shape', ''))
 ```
 
-Run `execute_code` to check schema. Update the cell again right away:
+Output: `sales DataFrame (1200, 4)`
 
 ```python
-# [Agent work]
-#
-# task: inspect notebook variables
-#
-# ```py
-# for name, val in kernel.globals.items():
-#     print(name, type(val).__name__, getattr(val, 'shape', ''))
-# ```
-#
-# summary: found `sales` DataFrame (1200, 4)
-# ---
-#
-# task: check data schema
-#
-# ```py
-# print(kernel.globals['sales'].dtypes)
-# ```
-#
-# summary: columns — date (datetime), region (str), revenue (float), units (int)
-# ---
+# What columns?
+print(sales.dtypes)
 ```
 
-Run `execute_code` to check imports. Update again:
+Output: `date datetime64, region object, revenue float64, units int64`
 
 ```python
-# [Agent work]
-#
-# task: inspect notebook variables
-# ...
-# ---
-#
-# task: check data schema
-# ...
-# ---
-#
-# task: check available plotting libraries
-#
-# ```py
-# import sys; [m for m in sys.modules if 'plot' in m or 'altair' in m]
-# ```
-#
-# summary: altair already imported
-# ---
+# What plotting libraries are available?
+import sys
+print([m for m in sys.modules if 'plot' in m or 'altair' in m])
 ```
 
-The user sees the cell growing probe by probe — never a long pause then a dump.
+Output: `['altair', 'altair.vegalite', ...]`
 
-## Step 3 — Ask in terminal chat
+## Step 2 — Ask in chat
 
 > "Your `sales` data has date, region, revenue, and units. You already have
 > altair. What kind of plot — line chart of revenue over time? Bar chart by
 > region? Something else?"
 
-## Step 4 — Add draft code to the cell
+User says: "Line chart of revenue over time, colored by region."
+
+## Step 3 — Write and validate
+
+Compile-check the code (needs the kernel preamble for graph access):
 
 ```python
-# [Agent work]
-#
-# task: inspect notebook variables
-# ...
-# ---
-#
-# task: check data schema
-# ...
-# ---
-#
-# task: check available plotting libraries
-# ...
-# ---
+from marimo._runtime.context import get_context
+from marimo._ast.compiler import compile_cell
+from marimo._types.ids import CellId_t
 
-# Draft code:
-
+code = """
 import altair as alt
 
 chart = alt.Chart(sales).mark_line().encode(
@@ -112,9 +58,29 @@ chart = alt.Chart(sales).mark_line().encode(
     color="region:N",
 )
 chart
+"""
+
+cell = compile_cell(code, cell_id=CellId_t("test"))
+print(f"defs={cell.defs}, refs={cell.refs}")
 ```
 
-## Step 5 — Execute
+Refs include `sales` — good, that's defined in an existing cell.
 
-The log stays as comments above the code. The user can see the full
-investigation trail and the final result together.
+Test it in the scratchpad to confirm it runs:
+
+```python
+import altair as alt
+
+chart = alt.Chart(sales).mark_line().encode(
+    x="date:T", y="revenue:Q", color="region:N",
+)
+print(type(chart))  # confirm it built without error
+```
+
+## Step 4 — Create the cell
+
+Now follow `create-cell` from [cell-operations.md](cell-operations.md) to add
+it to the notebook. Then `format-cell` to clean it up with ruff.
+
+The user sees one clean cell appear with the chart rendered. The scratchpad
+investigation and validation happened behind the scenes.


### PR DESCRIPTION
The skill document was front-loading too much process (turn-based workflow, working cell ritual, probe log format) before the user could find the actual API recipes. This restructures around two modes — scratchpad (simple inspection) and cell operations (complex mutations) — with a decision tree that routes to the right reference file.

Recipes are split from the monolithic kernel-api.md into scratchpad.md and cell-operations.md, each with its own focused preamble. The worked example is rewritten to match the new scratchpad-to-cell flow, dropping the verbose probe-log ceremony in favor of invisible scratchpad calls followed by one clean cell creation.

The guard rails are tightened: notify the frontend before executing (not after), and never write to the notebook file behind the kernel's back.