### PR TITLE
Prefer CLI over MCP for notebook interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 > [!WARNING]
 > This is an early-stage, experimental skill for use with [Claude Code](https://docs.anthropic.com/en/docs/claude-code). Expect rough edges — feedback and contributions welcome.
 
-A [Claude Code skill](https://docs.anthropic.com/en/docs/claude-code/skills) for pair programming in [marimo](https://marimo.io) notebooks via MCP.
+A [Claude Code skill](https://docs.anthropic.com/en/docs/claude-code/skills) for pair programming in [marimo](https://marimo.io) notebooks.
+
+You can interact with a running notebook via the **CLI** (`marimo session exec`) or via **MCP** tools. The skill prefers the CLI — it works everywhere with no extra setup.
 
 ## What it does
 
@@ -18,7 +20,7 @@ Key behaviors:
 ## Prerequisites
 
 - A running [marimo](https://marimo.io) notebook
-- The marimo MCP server connected to Claude Code (provides `get_active_notebooks` and `execute_code` tools)
+- marimo installed with the `marimo session` CLI available
 
 ## Install
 
@@ -37,21 +39,19 @@ Claude Code automatically discovers skills from these directories — no further
 ## Quick start
 
 ```bash
-# Add the marimo MCP server to Claude Code
-claude mcp add --transport http marimo "http://localhost:2718/mcp/server"
+# Start a marimo notebook
+marimo edit notebook.py
 
-# Start marimo in headless code-mode with MCP enabled
-uvx --with="marimo[mcp,recommended]" \
-  marimo edit notebook.py \
-  --mcp="code-mode" \
-  --no-token \
-  --headless \
-  --port 2718
+# In another terminal, verify the session is discoverable
+marimo session list
+
+# Execute code in the running session
+marimo session exec -c "print('hello')"
 ```
 
 ## Usage
 
-Start a marimo notebook, then talk to Claude Code. The skill activates automatically when it detects an active marimo session.
+Start a marimo notebook, then talk to Claude Code. The skill activates automatically when it detects a running marimo session via `marimo session list`.
 
 ```
 > let's explore this dataframe

--- a/SKILL.md
+++ b/SKILL.md
@@ -2,21 +2,51 @@
 name: marimo-pair
 description: >-
   Collaboration protocol for pairing with a user through a running marimo
-  notebook via MCP. Use when the user asks you to work in, build, explore,
-  or modify a marimo notebook — or when you detect an active marimo session
-  via get_active_notebooks / execute_code tools. Do NOT use for general
-  Python scripting outside of marimo or for marimo plugin/package development.
+  notebook via the CLI. Use when the user asks you to work in, build, explore,
+  or modify a marimo notebook — or when you detect a running marimo session
+  via `marimo session list`. Do NOT use for general Python scripting
+  outside of marimo or for marimo plugin/package development.
 ---
 
 # marimo Pair Programming Protocol
 
-You have MCP access to a running marimo notebook. This document defines how to
-use it as a thoughtful collaborator.
+You can interact with a running marimo notebook via the **CLI** or **MCP**.
+Prefer the CLI — it works everywhere with no extra setup. The workflow is
+identical either way; only the execution method differs.
+
+## CLI vs MCP
+
+There are two operations: listing sessions and executing code. Use whichever
+interface is available, preferring CLI.
+
+| Operation | CLI | MCP |
+|-----------|-----|-----|
+| List sessions | `marimo session list --json` | `list_sessions()` tool |
+| Execute code | `marimo session exec -c "code"` | `execute_code(code=..., session_id=...)` tool |
+
+### CLI details
+
+```bash
+# Auto-discovers the session if only one is running
+marimo session exec -c "print('hello')"
+
+# Target a specific server by port
+marimo session exec --port 2718 -c "print('hello')"
+
+# Target a specific session on a server
+marimo session exec --id <session-id> -c "print('hello')"
+```
+
+### MCP details
+
+If the marimo server was started with `--mcp`, you'll have `list_sessions`
+and `execute_code` tools available. Use them the same way — the recipes in
+this skill show CLI commands, but substitute the MCP tool call equivalents.
 
 ## Two Modes of Working
 
-`execute_code` is your only way to interact with the notebook. It serves two
-distinct purposes:
+`marimo session exec -c` is your only way to interact with the notebook. It
+serves two distinct purposes:
 
 **Scratchpad** (simple): Just Python — `print(df.head())`, check data shapes,
 test a snippet. The notebook's cell variables are already in scope. Results
@@ -33,7 +63,8 @@ frontend, then execute. Get it wrong and the UI desyncs.
 
 | Situation | Action |
 |-----------|--------|
-| Need to read data/state | Use recipes in [scratchpad.md](reference/scratchpad.md) |
+| Need to find running sessions | `marimo session list --json` |
+| Need to read data/state | Use recipes in [scratchpad.md](reference/scratchpad.md) via `marimo session exec -c` |
 | Need to create/edit/move/delete cells | Follow the scratchpad-to-cell workflow below, then use [cell-operations.md](reference/cell-operations.md) |
 | Unsure what API to use | See **Discovering the API** in [kernel-api.md](reference/kernel-api.md) |
 | Import path fails | See **Discovering the API** in [kernel-api.md](reference/kernel-api.md) |
@@ -54,7 +85,7 @@ real bugs before the user sees them.
    print(f"defs={cell.defs}, refs={cell.refs}")
    ```
    See `compile-check` in [scratchpad.md](reference/scratchpad.md) for full recipe.
-3. **Test in scratchpad** — run the code via `execute_code` to confirm it works. If it's expensive (network request, large query), test on a subset (smaller input, LIMIT clause, fewer params)
+3. **Test in scratchpad** — run the code via `marimo session exec -c` to confirm it works. If it's expensive (network request, large query), test on a subset (smaller input, LIMIT clause, fewer params)
 4. **If the code contains a network request or query**: consider asking the user before creating the cell, since execution will happen again when the cell runs. Or structure as two cells (fetch + transform) so the fetch only runs once
 5. **Create the cell** — follow `create-cell` in [cell-operations.md](reference/cell-operations.md)
 

--- a/reference/kernel-api.md
+++ b/reference/kernel-api.md
@@ -12,7 +12,7 @@ cell-mutation imports when you need to create, update, or delete cells.
 ## Discovering the API
 
 If an import fails or you need something not listed in the reference files,
-explore from within `execute_code`:
+explore from within `marimo session exec -c`:
 
 ```python
 import marimo

--- a/reference/scratchpad.md
+++ b/reference/scratchpad.md
@@ -1,7 +1,7 @@
 # Scratchpad Reference
 
-Recipes for using `execute_code` to inspect notebook state. Results come back
-to you — the user doesn't see them.
+Recipes for using `marimo session exec -c` to inspect notebook state. Results
+come back to you — the user doesn't see them.
 
 The scratchpad is just Python. You can `print(df.head())` or run any expression
 directly — the notebook's cell variables are already in scope. The preamble
@@ -9,8 +9,8 @@ below is only needed when you want to inspect kernel internals (graph structure,
 cell metadata, defs/refs).
 
 **Scoping:** Variables defined in the scratchpad do not persist between
-`execute_code` calls. Only notebook cell variables survive. Do all dependent
-work in a single call, and avoid polluting the kernel namespace.
+`marimo session exec` calls. Only notebook cell variables survive. Do all
+dependent work in a single call, and avoid polluting the kernel namespace.
 
 ## Contents
 

--- a/reference/worked-example.md
+++ b/reference/worked-example.md
@@ -4,9 +4,9 @@ This walks through the scratchpad-to-cell workflow from SKILL.md.
 
 ## Step 1 — Investigate via scratchpad
 
-Run `execute_code` calls to understand the notebook state. These are invisible
-to the user — just you gathering info. Cell variables are already in scope, so
-you can inspect them directly.
+Run `marimo session exec -c` calls to understand the notebook state. These are
+invisible to the user — just you gathering info. Cell variables are already in
+scope, so you can inspect them directly.
 
 ```python
 # What variables exist?


### PR DESCRIPTION
The skill previously assumed MCP as the only way to interact with a running marimo notebook, which required extra setup (starting the server with --mcp, registering the MCP server in Claude Code). The CLI (`marimo session exec`) works out of the box with any running marimo session and needs no configuration.

This updates all docs and the skill itself to prefer CLI commands over MCP tool calls, while keeping MCP as a documented alternative. A comparison table in SKILL.md shows the CLI and MCP equivalents side by side, and the quick start in README.md is simplified to just `marimo edit` plus `marimo session exec`.