### PR TITLE
Add optional call logging to execute-code.sh

### DIFF
--- a/scripts/execute-code.sh
+++ b/scripts/execute-code.sh
@@ -8,6 +8,11 @@
 #   execute-code.sh [--port PORT] script.py    # code from file
 set -euo pipefail
 
+# Optional eval logging: set EXECUTE_CODE_LOG to a file path to record each call
+if [[ -n "${EXECUTE_CODE_LOG:-}" ]]; then
+  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$EXECUTE_CODE_LOG"
+fi
+
 port=""
 code=""
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
The eval harness needs to count how many times `execute-code.sh` is invoked during a scenario run. Previously this required a wrapper script, but claude's skill invocations bypass the wrapper and call the real script directly, so the count was always wrong.

This adds a simple opt-in logging hook: when `EXECUTE_CODE_LOG` is set to a file path, each invocation appends a UTC timestamp to that file. The env var is unset by default so there's no impact outside of evals.