### PR TITLE
Shift pairing workflow from scratchpad-first to cell-first

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -117,22 +117,22 @@ async with cm.get_context() as ctx:
 
 ## Two Modes of Working
 
-**Scratchpad** (inspection only): Read state — `print(df.head())`, check data
-shapes, explore the API with `dir()`/`help()`. Cell variables are already in
-scope. Results come back to you — the user doesn't see them. You can also
-read and set UI element state programmatically (see
-[ui-state](reference/execute-code.md#ui-state)).
+**Cells** are persistent and visible — the user sees output, variables survive
+across executions, and code lives in the notebook. Code meant for the notebook
+should be written to the notebook.
 
-**Cell operations** (the main workflow): Creating, editing, moving, deleting
-cells. Work directly in cells — the compile-check catches structural issues,
-and runtime errors can be fixed in-place.
+**Scratchpad** is ephemeral and private — nothing persists between calls,
+the user can't see output, and variables don't enter the notebook scope.
+Use it for quick inspection: `print(df.head())`, `dir()`, `help()`, checking
+shapes and types. You can also manipulate UI state programmatically (see
+[ui-state](reference/execute-code.md#ui-state)).
 
 ## Decision Tree
 
 | Situation | Action |
 |-----------|--------|
 | Need to find running servers | Discover servers |
-| Need to read data/state | Use scratchpad recipes in [execute-code.md](reference/execute-code.md) |
+| Need to inspect data/state without persisting anything | Scratchpad — see [execute-code.md](reference/execute-code.md) |
 | Need to create/edit/move/delete cells | Follow the cell-first workflow below, then use [execute-code.md](reference/execute-code.md#cell-operations--mutating-the-notebook) |
 | Need to install a package | Use the `code_mode` context — see [Installing Packages](#installing-packages) |
 | Unsure what API to use | See **Discovering the API** in [execute-code.md](reference/execute-code.md#discovering-the-api) |
@@ -145,19 +145,15 @@ and runtime errors can be fixed in-place.
 
 ## Cell-First Workflow
 
-**Work directly in cells.** Create or edit cells in the notebook rather than
-testing in the scratchpad first. The `async with` context manager
-auto-compile-checks on exit — syntax errors, multiply-defined names, and
-cycles are caught before any graph mutation occurs. If the check fails, the
-operation is rejected and you get an error.
+**Work directly in cells.** Code that's meant for the notebook — computations,
+visualizations, transformations — should be authored in cells. The user can
+see output as it runs and variables persist in the notebook scope. If a cell
+has a runtime error, fix it in-place with `ctx.edit_cell()`.
 
-If a cell has a runtime error after creation, fix it in-place with
-`ctx.edit_cell()`. This is faster than scratchpad round-trips and the user
-sees progress incrementally.
-
-**Reserve the scratchpad for inspection only** — reading data shapes, checking
-variable state, exploring the API with `dir()`/`help()`. Don't use it to
-pre-test code that's going into a cell.
+**Use the scratchpad for ephemeral inspection** — checking shapes, reading
+variable state, exploring the API with `dir()`/`help()`. Scratchpad variables
+don't persist and output is invisible to the user (though mutations to
+existing notebook objects, like setting widget state, do take effect).
 
 ### Steps (same for add or edit)
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -117,16 +117,15 @@ async with cm.get_context() as ctx:
 
 ## Two Modes of Working
 
-**Scratchpad** (simple): Just Python — `print(df.head())`, check data shapes,
-test a snippet. Cell variables are already in scope. Results come back to
-you — the user doesn't see them. You can also read and set UI element state
-programmatically (see [ui-state](reference/execute-code.md#ui-state)). The
-kernel preamble in [execute-code.md](reference/execute-code.md) has the correct
-entry point and imports.
+**Scratchpad** (inspection only): Read state — `print(df.head())`, check data
+shapes, explore the API with `dir()`/`help()`. Cell variables are already in
+scope. Results come back to you — the user doesn't see them. You can also
+read and set UI element state programmatically (see
+[ui-state](reference/execute-code.md#ui-state)).
 
-**Cell operations** (complex): Creating, editing, moving, deleting cells.
-These require careful API orchestration — compile, register, notify the
-frontend, then execute. Get it wrong and the UI desyncs.
+**Cell operations** (the main workflow): Creating, editing, moving, deleting
+cells. Work directly in cells — the compile-check catches structural issues,
+and runtime errors can be fixed in-place.
 
 ## Decision Tree
 
@@ -134,7 +133,7 @@ frontend, then execute. Get it wrong and the UI desyncs.
 |-----------|--------|
 | Need to find running servers | Discover servers |
 | Need to read data/state | Use scratchpad recipes in [execute-code.md](reference/execute-code.md) |
-| Need to create/edit/move/delete cells | Follow the scratchpad-to-cell workflow below, then use [execute-code.md](reference/execute-code.md#cell-operations--mutating-the-notebook) |
+| Need to create/edit/move/delete cells | Follow the cell-first workflow below, then use [execute-code.md](reference/execute-code.md#cell-operations--mutating-the-notebook) |
 | Need to install a package | Use the `code_mode` context — see [Installing Packages](#installing-packages) |
 | Unsure what API to use | See **Discovering the API** in [execute-code.md](reference/execute-code.md#discovering-the-api) |
 | Import path fails | See **Discovering the API** in [execute-code.md](reference/execute-code.md#discovering-the-api) |
@@ -144,35 +143,29 @@ frontend, then execute. Get it wrong and the UI desyncs.
 | Need to display a notification to the user (toast, banner, focus) | See [other operations](reference/execute-code.md#other-operations) |
 | User asks to improve/optimize/clean up the notebook | See [notebook-improvements.md](reference/notebook-improvements.md) |
 
-## The Scratchpad-to-Cell Workflow
+## Cell-First Workflow
 
-**The cardinal rule: never show the user broken code.** Runtime errors in cells
-are a bad experience. Runtime errors in the scratchpad are invisible learning.
+**Work directly in cells.** Create or edit cells in the notebook rather than
+testing in the scratchpad first. The `async with` context manager
+auto-compile-checks on exit — syntax errors, multiply-defined names, and
+cycles are caught before any graph mutation occurs. If the check fails, the
+operation is rejected and you get an error.
 
-**Compile-check is not validation.** It catches syntax errors, broken refs, and
-cycles — but not wrong arguments, missing methods, or type mismatches. Don't
-let a passing compile-check give you false confidence.
+If a cell has a runtime error after creation, fix it in-place with
+`ctx.edit_cell()`. This is faster than scratchpad round-trips and the user
+sees progress incrementally.
 
-**ALWAYS test in the scratchpad before creating or editing a cell.** No
-exceptions unless the user explicitly says to skip testing. If the code is
-expensive, test on a subset — or if that's not possible, ask the user.
-
-The `async with` context manager automatically compile-checks on exit —
-syntax errors, multiply-defined names, and cycles are caught before any graph
-mutation occurs. If the check fails, the operation is rejected and you get an
-error. You don't need to compile-check manually.
-
-If testing passes, do the cell operation immediately — in the same execute-code
-call when possible. Never pause to ask; the only reason to pause is ambiguous
-intent.
+**Reserve the scratchpad for inspection only** — reading data shapes, checking
+variable state, exploring the API with `dir()`/`help()`. Don't use it to
+pre-test code that's going into a cell.
 
 ### Steps (same for add or edit)
 
 1. If editing, **read** the current cell code from the graph
-2. **Test in scratchpad** — run the code to validate at runtime
-3. **Create or update the cell** — the context manager auto-compile-checks.
-   If it fails, fix the code and retry. See
+2. **Create or update the cell** directly — the context manager
+   auto-compile-checks. If it fails, fix the code and retry. See
    [execute-code.md](reference/execute-code.md#cell-operations--mutating-the-notebook).
+3. If there's a runtime error, **edit the cell** to fix it.
 
 Keep cells small and focused — prefer splitting computation across cells and
 extracting helpers over large monolithic cells. Hide code by default so the

--- a/SKILL.md
+++ b/SKILL.md
@@ -157,16 +157,17 @@ existing notebook objects, like setting widget state, do take effect).
 
 ### Steps (same for add or edit)
 
+0. **Pause and think about units of work.** Before touching any cells, take a
+   quiet moment to consider what the user asked for and what belongs together.
+   Each cell should represent a coherent unit.
 1. If editing, **read** the current cell code from the graph
 2. **Create or update the cell** directly — the context manager
    auto-compile-checks. If it fails, fix the code and retry. See
    [execute-code.md](reference/execute-code.md#cell-operations--mutating-the-notebook).
 3. If there's a runtime error, **edit the cell** to fix it.
 
-Keep cells small and focused — prefer splitting computation across cells and
-extracting helpers over large monolithic cells. Hide code by default so the
-notebook reads as a clean document. Don't bother naming cells while working —
-names are optional and easier to add later when reviewing the notebook.
+Each cell should be one coherent unit of work — use your judgment on size.
+Hide code by default so the notebook reads as a clean document.
 
 ## Philosophy
 

--- a/reference/execute-code.md
+++ b/reference/execute-code.md
@@ -3,14 +3,14 @@
 Everything you do in the notebook goes through execute-code. This file covers
 both inspection (reading state) and mutation (creating/editing/deleting cells).
 
-## Scratchpad — inspecting state
+## Scratchpad — ephemeral inspection
 
-The scratchpad is just Python. Cell variables are already in scope — `print(df.head())`
+The scratchpad is just Python. Cell variables are in scope — `print(df.head())`
 works directly. Results come back to you; the user doesn't see them.
 
-**Scoping:** Variables defined in the scratchpad do not persist between
-execute-code calls. Only notebook cell variables survive. Do all dependent
-work in a single call.
+**Scoping:** Nothing persists between scratchpad calls — variables, imports,
+side-effects all reset. Only notebook cell variables survive. The only way to
+persist state is to add cells to the notebook.
 
 ### Kernel preamble
 
@@ -57,8 +57,9 @@ for name, val in kernel.globals.items():
 ### ui-state
 
 You can read and set the state of interactive elements from the scratchpad.
-This lets you drive the notebook programmatically — set a dropdown value,
-move a slider, enter text — without the user clicking anything.
+This lets you drive UI controls programmatically (set a dropdown, move a
+slider) without the user clicking anything. UI state changes propagate to
+the notebook even though scratchpad variables don't.
 
 **marimo UI elements** (`mo.ui.*`):
 

--- a/reference/gotchas.md
+++ b/reference/gotchas.md
@@ -10,7 +10,7 @@ The user may need to restart the kernel — but try known workarounds first.
 
 `df.to_pandas()` fails with `ModuleNotFoundError: pa.Table requires 'pyarrow'`.
 
-**Workaround** (scratchpad):
+**Workaround** — run in a cell (the side-effect must persist across executions):
 
 ```python
 import pyarrow as _pa

--- a/reference/rich-representations.md
+++ b/reference/rich-representations.md
@@ -252,9 +252,9 @@ Do **not** use `change["new"]` or `allow_self_loops=True`.
 traits reactive. This is rare — only use it when the full widget state should
 drive downstream cells, not just one trait.
 
-### Scratchpad access
+### Programmatic widget control (scratchpad)
 
-Read/write widget state from the scratchpad — no clicking:
+Read widget state or set UI controls from the scratchpad — no clicking:
 
 ```python
 print(timer.seconds)    # read


### PR DESCRIPTION
Previously, the skill described the scratchpad as an equal peer to cells. Agents over-used it — testing code in the scratchpad before writing cells, running experiments the user couldn't see. Now cells are the default: they're persistent, visible, and where notebook code belongs. The scratchpad is for ephemeral inspection only.