### PR TITLE
Document anywidget reactivity strategies and fix pyarrow workaround

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -164,6 +164,16 @@ Skip these and the UI breaks:
   hard to come up with while working. Skip them by default — it's easier
   to add meaningful names later when reviewing the notebook as a whole.
 
+## Widgets and Reactivity
+
+Anywidget state (traitlets) lives outside marimo's reactive graph. To hook a
+widget trait into the graph, pick one strategy per widget — never mix them:
+
+- **`mo.state` + `.observe()`** — you pick specific traits to bridge. Default choice.
+- **`mo.ui.anywidget()`** — wraps all synced traits into one reactive `.value`. Convenient but coarser.
+
+Read [rich-representations.md](reference/rich-representations.md) before wiring either.
+
 ## Keep in Mind
 
 - **The user is editing too.** The notebook can change between your calls —

--- a/reference/gotchas.md
+++ b/reference/gotchas.md
@@ -10,10 +10,15 @@ The user may need to restart the kernel — but try known workarounds first.
 
 `df.to_pandas()` fails with `ModuleNotFoundError: pa.Table requires 'pyarrow'`.
 
-**Workaround** — run in a cell (the side-effect must persist across executions):
+**Workaround** — if this error occurs after installing pyarrow mid-session,
+run the following via `execute-code` (scratchpad), NOT in a cell. The patch
+mutates the cached module object in the running kernel, so it doesn't need to
+persist in the notebook.
 
 ```python
 import pyarrow as _pa
 import polars.dataframe.frame as _frame_mod
 _frame_mod.pa = _pa
 ```
+
+Then re-run the failing cell.

--- a/reference/rich-representations.md
+++ b/reference/rich-representations.md
@@ -248,9 +248,14 @@ Initialize `mo.state()` with the widget's current trait value — not a
 hardcoded default. Read the trait directly off the widget in the lambda.
 Do **not** use `change["new"]` or `allow_self_loops=True`.
 
-**`mo.ui.anywidget(widget)`** wraps the *entire* widget and makes *all* synced
-traits reactive. This is rare — only use it when the full widget state should
-drive downstream cells, not just one trait.
+### `mo.state` + `.observe()` vs `mo.ui.anywidget()`
+
+Two strategies for reactive anywidgets. Choose one per widget — don't mix them.
+
+| Strategy | Reactivity | Best for |
+|----------|-----------|----------|
+| `mo.state` + `.observe()` | Specific traits you pick | Precision — only named traits trigger downstream cells |
+| `mo.ui.anywidget(widget)` | All synced traits as one `.value` dict | Convenience — observe everything at once |
 
 ### Programmatic widget control (scratchpad)
 


### PR DESCRIPTION
Anywidget traitlets live outside marimo's reactive graph, and there are two ways to bridge them in — `mo.state` + `.observe()` or `mo.ui.anywidget()`. Mixing the two on the same widget causes infinite re-execution loops. This adds a dedicated section in SKILL.md to make the choice visible early, with a decision table in the rich-representations reference for details.

Also fixes the pyarrow cached-module-proxy workaround in gotchas.md to recommend running the patch via the scratchpad rather than baking it into a cell, since it's a transient kernel fix that shouldn't persist in the notebook.