### PR TITLE
Remove `--no-skew-protection` flag from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Prerequisites
 
 - A running [marimo](https://marimo.io) notebook (started with
-  `--no-token --no-skew-protection`)
+  `--no-token`)
 - `bash`, `curl`, and `jq` available on `PATH`
 
 ## Install

--- a/SKILL.md
+++ b/SKILL.md
@@ -33,13 +33,13 @@ to the running notebook.
 
 ## Prerequisites
 
-The marimo server must be running with skew protection disabled. If the server
-uses token auth, pass the token via `--token` on the execute script.
+If the server uses token auth, pass the token via `--token` on the execute
+script.
 
 ### How to invoke marimo
 
-marimo must be invoked with `--no-token --no-skew-protection` to be
-discoverable. The right way to invoke it depends on context (project tooling,
+marimo must be invoked with `--no-token` to be discoverable. The right way to
+invoke it depends on context (project tooling,
 global install, sandbox mode). See
 [finding-marimo.md](reference/finding-marimo.md) for the full decision tree.
 

--- a/reference/finding-marimo.md
+++ b/reference/finding-marimo.md
@@ -3,7 +3,7 @@
 marimo must be invoked with these flags to be discoverable by this skill:
 
 ```sh
-marimo edit notebook.py --no-token --no-skew-protection [--sandbox]
+marimo edit notebook.py --no-token [--sandbox]
 ```
 
 How you invoke `marimo` depends on context — find the right way to run it.
@@ -24,17 +24,16 @@ specify it:
 
 ```sh
 # marimo is in [dependency-groups] → "notebooks" group
-uv run --group notebooks marimo edit notebook.py --no-token --no-skew-protection
+uv run --group notebooks marimo edit notebook.py --no-token
 ```
 
 Once you know marimo is available, use whatever CLI runner the project uses:
 
 ```sh
 # uv-managed project
-uv run marimo edit notebook.py --no-token --no-skew-protection
-
+uv run marimo edit notebook.py --no-token
 # pixi-managed project
-pixi run marimo edit notebook.py --no-token --no-skew-protection
+pixi run marimo edit notebook.py --no-token
 ```
 
 Skip `--sandbox` here — the project already manages dependencies.
@@ -50,10 +49,10 @@ metadata — so the notebook stays self-contained and reproducible.
 
 ```sh
 # With uv available (preferred)
-uvx marimo@latest edit notebook.py --no-token --no-skew-protection --sandbox
+uvx marimo@latest edit notebook.py --no-token --sandbox
 
 # With marimo installed globally
-marimo edit notebook.py --no-token --no-skew-protection --sandbox
+marimo edit notebook.py --no-token --sandbox
 ```
 
 ## Global marimo install


### PR DESCRIPTION
No longer necessary with https://github.com/marimo-team/marimo/pull/8993

The marimo execute-code endpoint no longer requires skew protection to be disabled, so this flag is no longer needed when invoking marimo for pairing. All command examples and prerequisite notes across SKILL.md, README.md, and the finding-marimo reference have been updated.