### PR TITLE
Widen allowed-tools glob for plugin cache paths

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Work inside a running marimo notebook's kernel — execute code, create cells,
   and build a notebook as an artifact. Use when the user wants to start a
   marimo notebook or work in an active marimo session.
-allowed-tools: Bash(bash */marimo-pair/scripts/discover-servers.sh), Bash(bash */marimo-pair/scripts/execute-code.sh*), Read
+allowed-tools: Bash(bash */marimo-pair/scripts/discover-servers.sh), Bash(bash */marimo-pair/*/scripts/discover-servers.sh), Bash(bash */marimo-pair/scripts/execute-code.sh*), Bash(bash */marimo-pair/*/scripts/execute-code.sh*), Read
 ---
 
 # marimo Pair Programming Protocol


### PR DESCRIPTION
The Claude plugin cache installs skills under a nested hash directory like `marimo-pair/<hash>/scripts/`, which didn't match the previous `*/marimo-pair/scripts/` pattern. The new `*marimo-pair*/scripts/` pattern lets the second `*` absorb the optional hash segment while still requiring `marimo-pair` in the path.