### PR TITLE
Add `--session` flag to execute-code.sh

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -59,8 +59,9 @@ Two operations: **discover servers** and **execute code**.
 | Execute code (direct URL) | `bash scripts/execute-code.sh --url URL -c "code"` | same (with `url` param) |
 
 Scripts auto-discover sessions from the registry on disk. Use `--port` to
-target a specific server when multiple are running, or `--url` to skip
-discovery entirely and hit a server URL directly (e.g.
+target a specific server when multiple are running, `--session` to target a
+specific session when multiple notebooks are open on the same server, or
+`--url` to skip discovery entirely and hit a server URL directly (e.g.
 `--url http://localhost:2718`). `--url` is the only way to connect to
 remote servers since auto-discovery only reads the local registry. Use
 `--token` to authenticate when the server has token auth enabled. If the

--- a/scripts/execute-code.sh
+++ b/scripts/execute-code.sh
@@ -2,13 +2,13 @@
 # Execute code in a running marimo session's scratchpad.
 # No marimo installation required — talks directly to the HTTP API.
 # Usage:
-#   execute-code.sh [--port PORT] [--token TOKEN] -c "code"   # inline code
-#   execute-code.sh [--port PORT] [--token TOKEN] script.py    # code from file
-#   execute-code.sh [--port PORT] [--token TOKEN] <<< "code"   # stdin (here-string)
-#   execute-code.sh [--port PORT] [--token TOKEN] <<'EOF'       # stdin (heredoc)
+#   execute-code.sh [--port PORT] [--session ID] [--token TOKEN] -c "code"   # inline code
+#   execute-code.sh [--port PORT] [--session ID] [--token TOKEN] script.py    # code from file
+#   execute-code.sh [--port PORT] [--session ID] [--token TOKEN] <<< "code"   # stdin (here-string)
+#   execute-code.sh [--port PORT] [--session ID] [--token TOKEN] <<'EOF'       # stdin (heredoc)
 #     code
 #   EOF
-#   execute-code.sh --url URL [--token TOKEN] -c "code"        # skip discovery, hit URL directly
+#   execute-code.sh --url URL [--session ID] [--token TOKEN] -c "code"        # skip discovery, hit URL directly
 set -euo pipefail
 
 # Optional eval logging: set EXECUTE_CODE_LOG to a file path to record each call
@@ -20,12 +20,14 @@ port=""
 code=""
 url=""
 token=""
+session=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --port)  port="$2"; shift 2 ;;
-    --url)   url="$2"; shift 2 ;;
-    --token) token="$2"; shift 2 ;;
-    -c)      code="$2"; shift 2 ;;
+    --port)    port="$2"; shift 2 ;;
+    --url)     url="$2"; shift 2 ;;
+    --token)   token="$2"; shift 2 ;;
+    --session) session="$2"; shift 2 ;;
+    -c)        code="$2"; shift 2 ;;
     -*)      echo "Unknown option: $1" >&2; exit 1 ;;
     *)       break ;;
   esac
@@ -111,27 +113,31 @@ if [[ -n "$token" ]]; then
 fi
 
 # Discover session ID
-sessions_resp=$(curl -sf "${auth_args[@]+"${auth_args[@]}"}" "${base}/api/sessions") || {
-  echo "Failed to connect to marimo server at ${base}" >&2
-  exit 1
-}
+if [[ -n "$session" ]]; then
+  session_id="$session"
+else
+  sessions_resp=$(curl -sf "${auth_args[@]+"${auth_args[@]}"}" "${base}/api/sessions") || {
+    echo "Failed to connect to marimo server at ${base}" >&2
+    exit 1
+  }
 
-session_ids=$(echo "$sessions_resp" | jq -r 'keys[]')
+  session_ids=$(echo "$sessions_resp" | jq -r 'keys[]')
 
-if [[ -z "$session_ids" ]]; then
-  echo "No active sessions on the server. Make sure a notebook is open in the browser." >&2
-  exit 1
+  if [[ -z "$session_ids" ]]; then
+    echo "No active sessions on the server. Make sure a notebook is open in the browser." >&2
+    exit 1
+  fi
+
+  session_count=$(echo "$session_ids" | wc -l | tr -d ' ')
+
+  if [[ $session_count -gt 1 ]]; then
+    echo "Multiple sessions on server. Cannot auto-select:" >&2
+    echo "$sessions_resp" | jq -r 'to_entries[] | "\(.key)  \(.value.filename // "")"' >&2
+    exit 1
+  fi
+
+  session_id=$(echo "$session_ids" | head -1)
 fi
-
-session_count=$(echo "$session_ids" | wc -l | tr -d ' ')
-
-if [[ $session_count -gt 1 ]]; then
-  echo "Multiple sessions on server. Cannot auto-select:" >&2
-  echo "$sessions_resp" | jq -r 'to_entries[] | "\(.key)  \(.value.filename // "")"' >&2
-  exit 1
-fi
-
-session_id=$(echo "$session_ids" | head -1)
 
 # Execute code via SSE stream
 # Events: stdout/stderr stream as JSON {"data":"..."}, done is final result.


### PR DESCRIPTION
When multiple notebooks are open on the same server, the script previously failed with "Multiple sessions on server. Cannot auto-select." The only workaround was dropping down to raw curl with the Marimo-Session-Id header.

This adds a `--session ID` flag that skips session auto-discovery and uses the provided ID directly. The multi-session error message already prints available session IDs, so a natural recovery is to re-run with `--session`.