### PR TITLE
Fix security warnings: prefer MARIMO_TOKEN env var, warn on remote URLs, drop curl|sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Prerequisites
 
 - A running [marimo](https://marimo.io) notebook (`--no-token` for
-  auto-discovery; `--token` for servers with auth)
+  auto-discovery; `MARIMO_TOKEN` env var for servers with auth)
 - `bash`, `curl`, and `jq` available on `PATH`
 
 ## Install

--- a/SKILL.md
+++ b/SKILL.md
@@ -37,7 +37,8 @@ to the running notebook.
 
 Only servers started with `--no-token` register in the local server registry
 and are auto-discoverable — starting without a token makes discovery easier.
-If a server has a token, pass it via `--token` on the execute script. The
+If a server has a token, set the `MARIMO_TOKEN` environment variable before
+calling the execute script (avoids leaking the token in process listings). The
 right way to invoke marimo depends on context (project
 tooling, global install, sandbox mode). See
 [finding-marimo.md](reference/finding-marimo.md) for the full decision tree.
@@ -63,15 +64,19 @@ target a specific server when multiple are running, `--session` to target a
 specific session when multiple notebooks are open on the same server, or
 `--url` to skip discovery entirely and hit a server URL directly (e.g.
 `--url http://localhost:2718`). `--url` is the only way to connect to
-remote servers since auto-discovery only reads the local registry. Use
-`--token` to authenticate when the server has token auth enabled. If the
+remote servers since auto-discovery only reads the local registry. **Only
+use `--url` with trusted servers** — data is sent to the endpoint, so a
+malicious URL could exfiltrate notebook contents. Set the `MARIMO_TOKEN`
+env var to authenticate when the server has token auth enabled (`--token`
+flag also works but exposes the token in process listings). If the
 server was started with `--mcp`, you'll have MCP tools available as an
 alternative.
 
 ### Discovery finds nothing but the user has a server running?
 
 Only `--no-token` servers are in the registry. If discovery comes up empty,
-the server likely has token auth — ask the user for the token.
+the server likely has token auth — ask the user for the token and set it as
+the `MARIMO_TOKEN` environment variable.
 
 ### No servers running?
 

--- a/reference/finding-marimo.md
+++ b/reference/finding-marimo.md
@@ -2,7 +2,8 @@
 
 Only servers started with `--no-token` register in the local server registry
 and are auto-discoverable — starting without a token makes discovery easier.
-If a server has a token, pass it via `--token` on the execute script.
+If a server has a token, set the `MARIMO_TOKEN` environment variable before
+calling the execute script (avoids leaking the token in process listings).
 
 ```sh
 marimo edit notebook.py --no-token [--sandbox]
@@ -66,4 +67,4 @@ proceeding.
 ## Nothing found
 
 If no project marimo, no `uv`/`uvx`, and no global `marimo` on PATH, tell the
-user to install `uv` (`curl -LsSf https://astral.sh/uv/install.sh | sh`).
+user to install `uv` (<https://docs.astral.sh/uv/getting-started/installation/>).

--- a/scripts/execute-code.sh
+++ b/scripts/execute-code.sh
@@ -2,13 +2,15 @@
 # Execute code in a running marimo session's scratchpad.
 # No marimo installation required — talks directly to the HTTP API.
 # Usage:
-#   execute-code.sh [--port PORT] [--session ID] [--token TOKEN] -c "code"   # inline code
-#   execute-code.sh [--port PORT] [--session ID] [--token TOKEN] script.py    # code from file
-#   execute-code.sh [--port PORT] [--session ID] [--token TOKEN] <<< "code"   # stdin (here-string)
-#   execute-code.sh [--port PORT] [--session ID] [--token TOKEN] <<'EOF'       # stdin (heredoc)
+#   execute-code.sh [--port PORT] [--session ID] -c "code"   # inline code
+#   execute-code.sh [--port PORT] [--session ID] script.py    # code from file
+#   execute-code.sh [--port PORT] [--session ID] <<< "code"   # stdin (here-string)
+#   execute-code.sh [--port PORT] [--session ID] <<'EOF'       # stdin (heredoc)
 #     code
 #   EOF
-#   execute-code.sh --url URL [--session ID] [--token TOKEN] -c "code"        # skip discovery, hit URL directly
+#   execute-code.sh --url URL [--session ID] -c "code"        # skip discovery, hit URL directly
+#
+# Auth: set MARIMO_TOKEN env var (preferred) or pass --token TOKEN (visible in ps).
 set -euo pipefail
 
 # Optional eval logging: set EXECUTE_CODE_LOG to a file path to record each call
@@ -19,7 +21,7 @@ fi
 port=""
 code=""
 url=""
-token=""
+token="${MARIMO_TOKEN:-}"
 session=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -40,14 +42,22 @@ elif [[ $# -gt 0 ]]; then
 elif [[ ! -t 0 ]]; then
   code=$(cat)
 else
-  echo "Usage: execute-code.sh [--port PORT | --url URL] [--token TOKEN] -c 'code'" >&2
-  echo "       execute-code.sh [--port PORT | --url URL] [--token TOKEN] script.py" >&2
-  echo "       echo 'code' | execute-code.sh [--port PORT | --url URL] [--token TOKEN]" >&2
+  echo "Usage: execute-code.sh [--port PORT | --url URL] -c 'code'" >&2
+  echo "       execute-code.sh [--port PORT | --url URL] script.py" >&2
+  echo "       echo 'code' | execute-code.sh [--port PORT | --url URL]" >&2
+  echo "Auth:  set MARIMO_TOKEN env var (preferred) or pass --token TOKEN" >&2
   exit 1
 fi
 
 if [[ -n "$url" ]]; then
   base="${url%/}"
+  # Warn when connecting to a non-local server (data exfiltration risk)
+  url_host="${url#*://}"
+  url_host="${url_host%%[:/]*}"
+  case "$url_host" in
+    localhost|127.0.0.1|::1|0.0.0.0) ;;
+    *) echo "Warning: connecting to non-local server '${url_host}'. Ensure this is trusted." >&2 ;;
+  esac
 else
   # Locate the servers directory
   if [[ "$OSTYPE" == msys* || "$OSTYPE" == cygwin* ]]; then


### PR DESCRIPTION
- Add MARIMO_TOKEN env var support to execute-code.sh (avoids token in ps output)
- Warn on stderr when --url points to a non-localhost server
- Replace curl-pipe-to-sh uv install recommendation with docs link
