### PR TITLE
Add FAQ for allowed-tools permission prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
   <video src="https://github.com/user-attachments/assets/d6d3f57a-e997-423c-bf14-8d9fba75e310" width="600" controls></video>
 </div>
 
-
 ## Prerequisites
 
 - A running [marimo](https://marimo.io) notebook (`--no-token` for
@@ -51,4 +50,24 @@ To opt in to auto-updates (recommended), so you always get the latest version:
 
 ```
 /plugin → Marketplaces → marimo-team-marimo-pair → Enable auto-update
+```
+
+## FAQ
+
+### I keep getting prompted to allow Bash commands
+
+The skill declares its own `allowed-tools`, but Claude Code may still prompt
+you to approve each Bash call. To avoid repeated prompts, copy the absolute
+paths to the scripts from the installed skill and add them to your
+`.claude/settings.json` (project-level) or `~/.claude/settings.json` (global):
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(bash /path/to/skills/marimo-pair/scripts/discover-servers.sh *)",
+      "Bash(bash /path/to/skills/marimo-pair/scripts/execute-code.sh *)"
+    ]
+  }
+}
 ```

--- a/SKILL.md
+++ b/SKILL.md
@@ -48,6 +48,26 @@ marimo auto-open the browser, which is the expected pairing experience. If the
 user explicitly requests headless, offer to open it with
 `open http://localhost:<port>`.
 
+## Troubleshooting
+
+### User keeps getting prompted to allow Bash commands
+
+The skill declares `allowed-tools` in its frontmatter, but Claude Code may
+still prompt for each Bash call. To fix this, the user should add the absolute
+paths to the scripts to their `.claude/settings.json` (project-level) or
+`~/.claude/settings.json` (global):
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(bash /absolute/path/to/skills/marimo-pair/scripts/discover-servers.sh *)",
+      "Bash(bash /absolute/path/to/skills/marimo-pair/scripts/execute-code.sh *)"
+    ]
+  }
+}
+```
+
 ## How to Discover Servers and Execute Code
 
 Two operations: **discover servers** and **execute code**.


### PR DESCRIPTION
Users frequently get prompted to approve every Bash call even though the skill declares `allowed-tools` in its frontmatter. This adds guidance in both the README (user-facing FAQ) and SKILL.md (agent-facing troubleshooting) on how to add the script paths to `settings.json` to suppress the prompts.