### PR TITLE
Fix Windows (Git Bash) server discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@
 
 - A running [marimo](https://marimo.io) notebook (`--no-token` for
   auto-discovery; `MARIMO_TOKEN` env var for servers with auth)
-- `bash`, `curl`, and `jq` available on `PATH`
+- `bash`, `curl`, and `jq` available on `PATH` (on Windows, run from
+  Git Bash)
 
 ## Install
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -45,8 +45,8 @@ tooling, global install, sandbox mode). See
 
 **Do NOT use `--headless` unless the user asks for it.** Omitting it lets
 marimo auto-open the browser, which is the expected pairing experience. If the
-user explicitly requests headless, offer to open it with
-`open http://localhost:<port>`.
+user explicitly requests headless, offer to open `http://localhost:<port>`
+in their browser (`open` on macOS, `xdg-open` on Linux, `start` on Windows).
 
 ## Troubleshooting
 
@@ -83,17 +83,22 @@ Scripts auto-discover sessions from the local server registry. Use
 `--port` to target a specific server when multiple are running,
 `--session` to target a specific session when multiple notebooks are
 open on the same server, or `--url` to skip discovery and connect to a
-server by URL (e.g. `--url http://localhost:2718`). Set the
-`MARIMO_TOKEN` env var to authenticate when the server has token auth
-enabled (`--token` flag also works but exposes the token in process
-listings). If the server was started with `--mcp`, you'll have MCP tools
-available as an alternative.
+server by URL (e.g. `--url http://localhost:2718`). **On Windows, prefer
+direct `--url` when registry discovery is empty** — see the next section
+for why. Set the `MARIMO_TOKEN` env var to authenticate when the server
+has token auth enabled (`--token` flag also works but exposes the token
+in process listings). If the server was started with `--mcp`, you'll
+have MCP tools available as an alternative.
 
 ### Discovery finds nothing but the user has a server running?
 
 Only `--no-token` servers are in the registry. If discovery comes up empty,
 the server likely has token auth — ask the user for the token and set it as
 the `MARIMO_TOKEN` environment variable.
+
+On **Windows (Git Bash / MSYS2)**, discovery can also come up empty even for
+a running `--no-token` server. If the user confirms marimo is reachable
+locally, fall back to `--url http://127.0.0.1:<port>` (ask for the port).
 
 ### No servers running?
 

--- a/scripts/discover-servers.sh
+++ b/scripts/discover-servers.sh
@@ -41,7 +41,9 @@ for f in "$servers_dir"/*.json; do
   [[ -e "$f" ]] || continue
 
   if ! check_live "$f"; then
-    rm -f "$f"
+    # On Windows the HTTP probe can fail transiently (slow start, busy server),
+    # so keep the entry; only POSIX `kill -0` is reliable enough to delete on.
+    [[ "$is_windows" == false ]] && rm -f "$f"
     continue
   fi
 

--- a/scripts/discover-servers.sh
+++ b/scripts/discover-servers.sh
@@ -5,7 +5,9 @@
 set -euo pipefail
 
 # Locate the servers directory
+is_windows=false
 if [[ "$OSTYPE" == msys* || "$OSTYPE" == cygwin* ]]; then
+  is_windows=true
   servers_dir="$HOME/.marimo/servers"
 else
   servers_dir="${XDG_STATE_HOME:-$HOME/.local/state}/marimo/servers"
@@ -22,10 +24,14 @@ for f in "$servers_dir"/*.json; do
 
   pid=$(jq -r '.pid' "$f" 2>/dev/null) || continue
 
-  # Clean up stale entries
-  if ! kill -0 "$pid" 2>/dev/null; then
-    rm -f "$f"
-    continue
+  # Skip the liveness check on Windows: Git Bash/MSYS2 `kill` operates on
+  # Cygwin PIDs, not the native Windows PIDs marimo writes, so it would
+  # treat every live server as dead and delete valid registry entries.
+  if [[ "$is_windows" == false ]]; then
+    if ! kill -0 "$pid" 2>/dev/null; then
+      rm -f "$f"
+      continue
+    fi
   fi
 
   entry=$(jq '.' "$f" 2>/dev/null) || continue

--- a/scripts/discover-servers.sh
+++ b/scripts/discover-servers.sh
@@ -18,20 +18,31 @@ if [[ ! -d "$servers_dir" ]]; then
   exit 0
 fi
 
+# Liveness check. On POSIX, `kill -0 $pid` is cheap and reliable. On Windows
+# (Git Bash/MSYS2) `kill` operates on Cygwin PIDs, not the native Windows PIDs
+# marimo writes, so fall back to an HTTP probe against marimo's /health.
+check_live() {
+  local f="$1"
+  if [[ "$is_windows" == false ]]; then
+    local pid
+    pid=$(jq -r '.pid' "$f" 2>/dev/null) || return 1
+    kill -0 "$pid" 2>/dev/null
+  else
+    local host port base_url
+    host=$(jq -r '.host' "$f" 2>/dev/null) || return 1
+    port=$(jq -r '.port' "$f" 2>/dev/null) || return 1
+    base_url=$(jq -r '.base_url' "$f" 2>/dev/null) || return 1
+    curl -sf --max-time 1 "http://${host}:${port}${base_url}/health" >/dev/null 2>&1
+  fi
+}
+
 results="[]"
 for f in "$servers_dir"/*.json; do
   [[ -e "$f" ]] || continue
 
-  pid=$(jq -r '.pid' "$f" 2>/dev/null) || continue
-
-  # Skip the liveness check on Windows: Git Bash/MSYS2 `kill` operates on
-  # Cygwin PIDs, not the native Windows PIDs marimo writes, so it would
-  # treat every live server as dead and delete valid registry entries.
-  if [[ "$is_windows" == false ]]; then
-    if ! kill -0 "$pid" 2>/dev/null; then
-      rm -f "$f"
-      continue
-    fi
+  if ! check_live "$f"; then
+    rm -f "$f"
+    continue
   fi
 
   entry=$(jq '.' "$f" 2>/dev/null) || continue

--- a/scripts/execute-code.sh
+++ b/scripts/execute-code.sh
@@ -60,7 +60,9 @@ if [[ -n "$url" ]]; then
   esac
 else
   # Locate the servers directory
+  is_windows=false
   if [[ "$OSTYPE" == msys* || "$OSTYPE" == cygwin* ]]; then
+    is_windows=true
     servers_dir="$HOME/.marimo/servers"
   else
     servers_dir="${XDG_STATE_HOME:-$HOME/.local/state}/marimo/servers"
@@ -73,9 +75,14 @@ else
     [[ -e "$f" ]] || continue
 
     pid=$(jq -r '.pid' "$f" 2>/dev/null) || continue
-    if ! kill -0 "$pid" 2>/dev/null; then
-      rm -f "$f"
-      continue
+    # Skip the liveness check on Windows: Git Bash/MSYS2 `kill` operates on
+    # Cygwin PIDs, not the native Windows PIDs marimo writes, so it would
+    # treat every live server as dead and delete valid registry entries.
+    if [[ "$is_windows" == false ]]; then
+      if ! kill -0 "$pid" 2>/dev/null; then
+        rm -f "$f"
+        continue
+      fi
     fi
 
     e=$(cat "$f")
@@ -104,7 +111,9 @@ else
     for f in "$servers_dir"/*.json; do
       [[ -e "$f" ]] || continue
       pid=$(jq -r '.pid' "$f" 2>/dev/null) || continue
-      kill -0 "$pid" 2>/dev/null || continue
+      if [[ "$is_windows" == false ]]; then
+        kill -0 "$pid" 2>/dev/null || continue
+      fi
       jq -r '.server_id' "$f" >&2
     done
     exit 1

--- a/scripts/execute-code.sh
+++ b/scripts/execute-code.sh
@@ -68,21 +68,33 @@ else
     servers_dir="${XDG_STATE_HOME:-$HOME/.local/state}/marimo/servers"
   fi
 
+  # Liveness check. On POSIX, `kill -0 $pid` is cheap and reliable. On Windows
+  # (Git Bash/MSYS2) `kill` operates on Cygwin PIDs, not the native Windows PIDs
+  # marimo writes, so fall back to an HTTP probe against marimo's /health.
+  check_live() {
+    local f="$1"
+    if [[ "$is_windows" == false ]]; then
+      local pid
+      pid=$(jq -r '.pid' "$f" 2>/dev/null) || return 1
+      kill -0 "$pid" 2>/dev/null
+    else
+      local host port base_url
+      host=$(jq -r '.host' "$f" 2>/dev/null) || return 1
+      port=$(jq -r '.port' "$f" 2>/dev/null) || return 1
+      base_url=$(jq -r '.base_url' "$f" 2>/dev/null) || return 1
+      curl -sf --max-time 1 "http://${host}:${port}${base_url}/health" >/dev/null 2>&1
+    fi
+  }
+
   # Find a live registry entry
   entry=""
   count=0
   for f in "$servers_dir"/*.json; do
     [[ -e "$f" ]] || continue
 
-    pid=$(jq -r '.pid' "$f" 2>/dev/null) || continue
-    # Skip the liveness check on Windows: Git Bash/MSYS2 `kill` operates on
-    # Cygwin PIDs, not the native Windows PIDs marimo writes, so it would
-    # treat every live server as dead and delete valid registry entries.
-    if [[ "$is_windows" == false ]]; then
-      if ! kill -0 "$pid" 2>/dev/null; then
-        rm -f "$f"
-        continue
-      fi
+    if ! check_live "$f"; then
+      rm -f "$f"
+      continue
     fi
 
     e=$(cat "$f")
@@ -110,10 +122,7 @@ else
     echo "Multiple instances found. Use --port to specify:" >&2
     for f in "$servers_dir"/*.json; do
       [[ -e "$f" ]] || continue
-      pid=$(jq -r '.pid' "$f" 2>/dev/null) || continue
-      if [[ "$is_windows" == false ]]; then
-        kill -0 "$pid" 2>/dev/null || continue
-      fi
+      check_live "$f" || continue
       jq -r '.server_id' "$f" >&2
     done
     exit 1

--- a/scripts/execute-code.sh
+++ b/scripts/execute-code.sh
@@ -93,7 +93,9 @@ else
     [[ -e "$f" ]] || continue
 
     if ! check_live "$f"; then
-      rm -f "$f"
+      # On Windows the HTTP probe can fail transiently (slow start, busy server),
+      # so keep the entry; only POSIX `kill -0` is reliable enough to delete on.
+      [[ "$is_windows" == false ]] && rm -f "$f"
       continue
     fi
 


### PR DESCRIPTION
Git Bash/MSYS2 `kill` operates on Cygwin PIDs, not the native Windows
PIDs marimo writes to the registry, so the liveness check treated every
live server as dead and `rm -f`'d valid registry entries — leaving
discovery empty. Skip the check on Windows and document `--url` as the
fallback when registry discovery returns nothing.

Closes #29