### PR TITLE
Update package install API to `ctx.packages.add()`

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -155,7 +155,7 @@ import marimo._code_mode as cm
 
 async with cm.get_context() as ctx:
     cid = ctx.create_cell("x = 1")
-    ctx.install_packages("pandas")
+    ctx.packages.add("pandas")
     ctx.run_cell(cid)
 ```
 
@@ -194,7 +194,7 @@ help(cm)
 
 Skip these and the UI breaks:
 
-- **Install packages via `ctx.install_packages()`, not `uv add` or `pip`.**
+- **Install packages via `ctx.packages.add()`, not `uv add` or `pip`.**
   The code API handles kernel restarts and dependency resolution correctly.
   Only fall back to external CLIs if the API is unavailable or fails.
 - **Custom widget = anywidget.** For bespoke visual components, use anywidget
@@ -224,7 +224,7 @@ Read [rich-representations.md](reference/rich-representations.md) before wiring 
 - **Deletions are destructive.** Deleting a cell removes its variables from
   kernel memory — restoring means recreating the cell and re-running it and
   its dependents. If intent seems ambiguous, ask first.
-- **Installing packages changes the project.** `ctx.install_packages()` adds
+- **Installing packages changes the project.** `ctx.packages.add()` adds
   real dependencies — confirm when it's not obvious from context.
 
 ## References

--- a/reference/gotchas.md
+++ b/reference/gotchas.md
@@ -45,7 +45,7 @@ tree = ast.parse(src)
 ## Cached module availability
 
 Some libraries cache optional-dependency availability at import time. Installing
-a package mid-session via `ctx.install_packages()` won't update those caches.
+a package mid-session via `ctx.packages.add()` won't update those caches.
 The user may need to restart the kernel — but try known workarounds first.
 
 ### Polars + pyarrow


### PR DESCRIPTION
Pending on marimo-team/marimo#9233

The code mode API for package installation changed from a single `ctx.install_packages()` method to a `ctx.packages` namespace, with `add()` as the install entry point. This brings the docs in line with the current API so examples actually run, and leaves room for related package operations (remove, list) to live under the same namespace.

`ctx.install_packages()` still will work (but with deprecation notice).