### PR TITLE
Fix script discovery and output handling on Windows (WSL + Git Bash)

### DIFF
--- a/scripts/discover-servers.sh
+++ b/scripts/discover-servers.sh
@@ -4,19 +4,50 @@
 # No marimo installation required.
 set -euo pipefail
 
-# Locate the servers directory
-is_windows=false
-if [[ "$OSTYPE" == msys* || "$OSTYPE" == cygwin* ]]; then
-  is_windows=true
-  servers_dir="$HOME/.marimo/servers"
-else
-  servers_dir="${XDG_STATE_HOME:-$HOME/.local/state}/marimo/servers"
+# Locate the servers directory. Several shells can read marimo's registry,
+# and they don't all agree on where it lives:
+#   * Linux/macOS native        -> $XDG_STATE_HOME/marimo/servers (POSIX path)
+#   * MSYS2 / Cygwin / Git Bash -> $HOME/.marimo/servers (Windows-native marimo)
+#   * WSL pointed at Windows    -> $USERPROFILE translated via wslpath/cygpath
+#                                  -> .../.marimo/servers
+# OSTYPE-based detection misses the WSL case (OSTYPE=linux-gnu there), so we
+# scan all candidates and use the first one that actually has registry files.
+candidates=(
+  "${XDG_STATE_HOME:-$HOME/.local/state}/marimo/servers"
+  "$HOME/.marimo/servers"
+)
+if [[ -n "${USERPROFILE:-}" ]]; then
+  if command -v wslpath >/dev/null 2>&1; then
+    win_home=$(wslpath -u "$USERPROFILE" 2>/dev/null) || win_home=""
+  elif command -v cygpath >/dev/null 2>&1; then
+    win_home=$(cygpath -u "$USERPROFILE" 2>/dev/null) || win_home=""
+  else
+    win_home=""
+  fi
+  [[ -n "$win_home" ]] && candidates+=("$win_home/.marimo/servers")
 fi
 
-if [[ ! -d "$servers_dir" ]]; then
+servers_dir=""
+for d in "${candidates[@]}"; do
+  if [[ -d "$d" ]] && compgen -G "$d/*.json" >/dev/null 2>&1; then
+    servers_dir="$d"
+    break
+  fi
+done
+
+if [[ -z "$servers_dir" ]]; then
   echo "[]"
   exit 0
 fi
+
+# A registry living at .../.marimo/servers belongs to a Windows-native marimo
+# (Git Bash, Cygwin, or WSL pointed at Windows) — its PIDs are Windows PIDs
+# and won't respond to `kill -0` from any of those shells. Use HTTP probes
+# in that case. The XDG path is always native POSIX.
+case "$servers_dir" in
+  */.marimo/servers) is_windows=true ;;
+  *)                 is_windows=false ;;
+esac
 
 # Liveness check. On POSIX, `kill -0 $pid` is cheap and reliable. On Windows
 # (Git Bash/MSYS2) `kill` operates on Cygwin PIDs, not the native Windows PIDs

--- a/scripts/discover-servers.sh
+++ b/scripts/discover-servers.sh
@@ -4,14 +4,16 @@
 # No marimo installation required.
 set -euo pipefail
 
-# Locate the servers directory. Several shells can read marimo's registry,
-# and they don't all agree on where it lives:
+# Build the candidate list of registry directories. Several shells can read
+# marimo's registry, and they don't all agree on where it lives:
 #   * Linux/macOS native        -> $XDG_STATE_HOME/marimo/servers (POSIX path)
 #   * MSYS2 / Cygwin / Git Bash -> $HOME/.marimo/servers (Windows-native marimo)
 #   * WSL pointed at Windows    -> $USERPROFILE translated via wslpath/cygpath
 #                                  -> .../.marimo/servers
-# OSTYPE-based detection misses the WSL case (OSTYPE=linux-gnu there), so we
-# scan all candidates and use the first one that actually has registry files.
+# OSTYPE-based detection misses the WSL case (OSTYPE=linux-gnu there), and
+# selecting just the first candidate that *contains files* fails when one
+# candidate has only stale entries while another has the live server. So we
+# scan every candidate and aggregate live entries across all of them.
 candidates=(
   "${XDG_STATE_HOME:-$HOME/.local/state}/marimo/servers"
   "$HOME/.marimo/servers"
@@ -27,31 +29,29 @@ if [[ -n "${USERPROFILE:-}" ]]; then
   [[ -n "$win_home" ]] && candidates+=("$win_home/.marimo/servers")
 fi
 
-servers_dir=""
+# Dedupe by string. On Git Bash $HOME and the cygpath translation of
+# $USERPROFILE typically resolve to the same path (e.g. /c/Users/foo), and
+# without dedupe the same server is listed twice. O(n^2) loop is fine — the
+# candidate list never exceeds a handful.
+deduped=()
 for d in "${candidates[@]}"; do
-  if [[ -d "$d" ]] && compgen -G "$d/*.json" >/dev/null 2>&1; then
-    servers_dir="$d"
-    break
-  fi
+  is_dup=false
+  for e in "${deduped[@]+${deduped[@]}}"; do
+    if [[ "$e" == "$d" ]]; then
+      is_dup=true
+      break
+    fi
+  done
+  $is_dup || deduped+=("$d")
 done
-
-if [[ -z "$servers_dir" ]]; then
-  echo "[]"
-  exit 0
-fi
-
-# A registry living at .../.marimo/servers belongs to a Windows-native marimo
-# (Git Bash, Cygwin, or WSL pointed at Windows) — its PIDs are Windows PIDs
-# and won't respond to `kill -0` from any of those shells. Use HTTP probes
-# in that case. The XDG path is always native POSIX.
-case "$servers_dir" in
-  */.marimo/servers) is_windows=true ;;
-  *)                 is_windows=false ;;
-esac
+candidates=("${deduped[@]}")
 
 # Liveness check. On POSIX, `kill -0 $pid` is cheap and reliable. On Windows
-# (Git Bash/MSYS2) `kill` operates on Cygwin PIDs, not the native Windows PIDs
-# marimo writes, so fall back to an HTTP probe against marimo's /health.
+# (Git Bash/MSYS2/WSL pointed at Windows) `kill` operates on Cygwin/Linux PIDs,
+# not the native Windows PIDs marimo writes, so fall back to an HTTP probe
+# against marimo's /health. The ``is_windows`` flag is set per candidate
+# directory below — a registry living at .../.marimo/servers always houses
+# Windows-native PIDs regardless of which shell is reading it.
 check_live() {
   local f="$1"
   if [[ "$is_windows" == false ]]; then
@@ -67,19 +67,30 @@ check_live() {
   fi
 }
 
+# Walk every candidate, applying per-candidate liveness rules, and collect
+# every live entry. A stale POSIX/XDG registry can't shadow a live Windows-
+# native one this way, and a user with two live marimos in different
+# registries (rare but possible) sees both.
 results="[]"
-for f in "$servers_dir"/*.json; do
-  [[ -e "$f" ]] || continue
+for d in "${candidates[@]}"; do
+  [[ -d "$d" ]] || continue
+  case "$d" in
+    */.marimo/servers) is_windows=true ;;
+    *)                 is_windows=false ;;
+  esac
+  for f in "$d"/*.json; do
+    [[ -e "$f" ]] || continue
 
-  if ! check_live "$f"; then
-    # On Windows the HTTP probe can fail transiently (slow start, busy server),
-    # so keep the entry; only POSIX `kill -0` is reliable enough to delete on.
-    [[ "$is_windows" == false ]] && rm -f "$f"
-    continue
-  fi
+    if ! check_live "$f"; then
+      # On Windows the HTTP probe can fail transiently (slow start, busy server),
+      # so keep the entry; only POSIX `kill -0` is reliable enough to delete on.
+      [[ "$is_windows" == false ]] && rm -f "$f"
+      continue
+    fi
 
-  entry=$(jq '.' "$f" 2>/dev/null) || continue
-  results=$(echo "$results" | jq --argjson e "$entry" '. + [$e]')
+    entry=$(jq '.' "$f" 2>/dev/null) || continue
+    results=$(echo "$results" | jq --argjson e "$entry" '. + [$e]')
+  done
 done
 
 echo "$results" | jq .

--- a/scripts/execute-code.sh
+++ b/scripts/execute-code.sh
@@ -59,14 +59,16 @@ if [[ -n "$url" ]]; then
     *) echo "Warning: connecting to non-local server '${url_host}'. Ensure this is trusted." >&2 ;;
   esac
 else
-  # Locate the servers directory. Several shells can read marimo's registry,
-  # and they don't all agree on where it lives:
+  # Build the candidate list of registry directories. Several shells can read
+  # marimo's registry, and they don't all agree on where it lives:
   #   * Linux/macOS native        -> $XDG_STATE_HOME/marimo/servers (POSIX path)
   #   * MSYS2 / Cygwin / Git Bash -> $HOME/.marimo/servers (Windows-native marimo)
   #   * WSL pointed at Windows    -> $USERPROFILE translated via wslpath/cygpath
   #                                  -> .../.marimo/servers
-  # OSTYPE-based detection misses the WSL case (OSTYPE=linux-gnu there), so we
-  # scan all candidates and use the first one that actually has registry files.
+  # OSTYPE-based detection misses the WSL case (OSTYPE=linux-gnu there), and
+  # selecting just the first candidate that *contains files* fails when one
+  # candidate has only stale entries while another has the live server. So we
+  # scan every candidate and aggregate live entries across all of them.
   candidates=(
     "${XDG_STATE_HOME:-$HOME/.local/state}/marimo/servers"
     "$HOME/.marimo/servers"
@@ -82,27 +84,29 @@ else
     [[ -n "$win_home" ]] && candidates+=("$win_home/.marimo/servers")
   fi
 
-  servers_dir=""
+  # Dedupe by string. On Git Bash $HOME and the cygpath translation of
+  # $USERPROFILE typically resolve to the same path (e.g. /c/Users/foo), and
+  # without dedupe the same server is counted twice. O(n^2) loop is fine —
+  # the candidate list never exceeds a handful.
+  deduped=()
   for d in "${candidates[@]}"; do
-    if [[ -d "$d" ]] && compgen -G "$d/*.json" >/dev/null 2>&1; then
-      servers_dir="$d"
-      break
-    fi
+    is_dup=false
+    for e in "${deduped[@]+${deduped[@]}}"; do
+      if [[ "$e" == "$d" ]]; then
+        is_dup=true
+        break
+      fi
+    done
+    $is_dup || deduped+=("$d")
   done
-  [[ -z "$servers_dir" ]] && servers_dir="${candidates[0]}"
-
-  # A registry living at .../.marimo/servers belongs to a Windows-native marimo
-  # (Git Bash, Cygwin, or WSL pointed at Windows) — its PIDs are Windows PIDs
-  # and won't respond to `kill -0` from any of those shells. Use HTTP probes
-  # in that case. The XDG path is always native POSIX.
-  case "$servers_dir" in
-    */.marimo/servers) is_windows=true ;;
-    *)                 is_windows=false ;;
-  esac
+  candidates=("${deduped[@]}")
 
   # Liveness check. On POSIX, `kill -0 $pid` is cheap and reliable. On Windows
-  # (Git Bash/MSYS2) `kill` operates on Cygwin PIDs, not the native Windows PIDs
-  # marimo writes, so fall back to an HTTP probe against marimo's /health.
+  # (Git Bash/MSYS2/WSL pointed at Windows) `kill` operates on Cygwin/Linux PIDs,
+  # not the native Windows PIDs marimo writes, so fall back to an HTTP probe
+  # against marimo's /health. The ``is_windows`` flag is set per candidate
+  # directory below — a registry living at .../.marimo/servers always houses
+  # Windows-native PIDs regardless of which shell is reading it.
   check_live() {
     local f="$1"
     if [[ "$is_windows" == false ]]; then
@@ -118,33 +122,43 @@ else
     fi
   }
 
-  # Find a live registry entry
+  # Walk every candidate, applying per-candidate liveness rules, and find live
+  # registry entries. ``--port`` short-circuits on first match; otherwise we
+  # tally across all candidates so a stale POSIX/XDG registry can't shadow a
+  # live Windows-native one (and vice versa).
   entry=""
   count=0
-  for f in "$servers_dir"/*.json; do
-    [[ -e "$f" ]] || continue
+  for d in "${candidates[@]}"; do
+    [[ -d "$d" ]] || continue
+    case "$d" in
+      */.marimo/servers) is_windows=true ;;
+      *)                 is_windows=false ;;
+    esac
+    for f in "$d"/*.json; do
+      [[ -e "$f" ]] || continue
 
-    if ! check_live "$f"; then
-      # On Windows the HTTP probe can fail transiently (slow start, busy server),
-      # so keep the entry; only POSIX `kill -0` is reliable enough to delete on.
-      [[ "$is_windows" == false ]] && rm -f "$f"
-      continue
-    fi
-
-    e=$(cat "$f")
-
-    if [[ -n "$port" ]]; then
-      e_port=$(echo "$e" | jq -r '.port')
-      if [[ "$e_port" == "$port" ]]; then
-        entry="$e"
-        count=1
-        break
+      if ! check_live "$f"; then
+        # On Windows the HTTP probe can fail transiently (slow start, busy server),
+        # so keep the entry; only POSIX `kill -0` is reliable enough to delete on.
+        [[ "$is_windows" == false ]] && rm -f "$f"
+        continue
       fi
-      continue
-    fi
 
-    entry="$e"
-    count=$((count + 1))
+      e=$(cat "$f")
+
+      if [[ -n "$port" ]]; then
+        e_port=$(echo "$e" | jq -r '.port')
+        if [[ "$e_port" == "$port" ]]; then
+          entry="$e"
+          count=1
+          break 2
+        fi
+        continue
+      fi
+
+      entry="$e"
+      count=$((count + 1))
+    done
   done
 
   if [[ $count -eq 0 ]]; then
@@ -154,10 +168,17 @@ else
 
   if [[ $count -gt 1 ]]; then
     echo "Multiple instances found. Use --port to specify:" >&2
-    for f in "$servers_dir"/*.json; do
-      [[ -e "$f" ]] || continue
-      check_live "$f" || continue
-      jq -r '.server_id' "$f" >&2
+    for d in "${candidates[@]}"; do
+      [[ -d "$d" ]] || continue
+      case "$d" in
+        */.marimo/servers) is_windows=true ;;
+        *)                 is_windows=false ;;
+      esac
+      for f in "$d"/*.json; do
+        [[ -e "$f" ]] || continue
+        check_live "$f" || continue
+        jq -r '.server_id' "$f" >&2
+      done
     done
     exit 1
   fi

--- a/scripts/execute-code.sh
+++ b/scripts/execute-code.sh
@@ -59,14 +59,46 @@ if [[ -n "$url" ]]; then
     *) echo "Warning: connecting to non-local server '${url_host}'. Ensure this is trusted." >&2 ;;
   esac
 else
-  # Locate the servers directory
-  is_windows=false
-  if [[ "$OSTYPE" == msys* || "$OSTYPE" == cygwin* ]]; then
-    is_windows=true
-    servers_dir="$HOME/.marimo/servers"
-  else
-    servers_dir="${XDG_STATE_HOME:-$HOME/.local/state}/marimo/servers"
+  # Locate the servers directory. Several shells can read marimo's registry,
+  # and they don't all agree on where it lives:
+  #   * Linux/macOS native        -> $XDG_STATE_HOME/marimo/servers (POSIX path)
+  #   * MSYS2 / Cygwin / Git Bash -> $HOME/.marimo/servers (Windows-native marimo)
+  #   * WSL pointed at Windows    -> $USERPROFILE translated via wslpath/cygpath
+  #                                  -> .../.marimo/servers
+  # OSTYPE-based detection misses the WSL case (OSTYPE=linux-gnu there), so we
+  # scan all candidates and use the first one that actually has registry files.
+  candidates=(
+    "${XDG_STATE_HOME:-$HOME/.local/state}/marimo/servers"
+    "$HOME/.marimo/servers"
+  )
+  if [[ -n "${USERPROFILE:-}" ]]; then
+    if command -v wslpath >/dev/null 2>&1; then
+      win_home=$(wslpath -u "$USERPROFILE" 2>/dev/null) || win_home=""
+    elif command -v cygpath >/dev/null 2>&1; then
+      win_home=$(cygpath -u "$USERPROFILE" 2>/dev/null) || win_home=""
+    else
+      win_home=""
+    fi
+    [[ -n "$win_home" ]] && candidates+=("$win_home/.marimo/servers")
   fi
+
+  servers_dir=""
+  for d in "${candidates[@]}"; do
+    if [[ -d "$d" ]] && compgen -G "$d/*.json" >/dev/null 2>&1; then
+      servers_dir="$d"
+      break
+    fi
+  done
+  [[ -z "$servers_dir" ]] && servers_dir="${candidates[0]}"
+
+  # A registry living at .../.marimo/servers belongs to a Windows-native marimo
+  # (Git Bash, Cygwin, or WSL pointed at Windows) — its PIDs are Windows PIDs
+  # and won't respond to `kill -0` from any of those shells. Use HTTP probes
+  # in that case. The XDG path is always native POSIX.
+  case "$servers_dir" in
+    */.marimo/servers) is_windows=true ;;
+    *)                 is_windows=false ;;
+  esac
 
   # Liveness check. On POSIX, `kill -0 $pid` is cheap and reliable. On Windows
   # (Git Bash/MSYS2) `kill` operates on Cygwin PIDs, not the native Windows PIDs
@@ -175,6 +207,11 @@ exit_code=0
 current_event=""
 done_received=false
 while IFS= read -r line && [[ "$done_received" == false ]]; do
+  # marimo's HTTP server uses CRLF line terminators on the SSE stream
+  # (per the spec). bash's `read -r` strips the LF but leaves the CR,
+  # so the literal-prefix patterns below would never match on Windows
+  # (Git Bash and WSL) without this trim. Cheap to do unconditionally.
+  line="${line%$'\r'}"
   case "$line" in
     event:*)
       current_event="${line#event: }"


### PR DESCRIPTION
Fixes #42.

Two related bugs hit users on Windows-hosted bash environments where marimo runs natively on Windows but the agent scripts run under a non-MSYS bash. Both are scoped to `scripts/discover-servers.sh` and `scripts/execute-code.sh`.

## Bug 1 — discovery picks the wrong registry path under WSL

Both scripts only treat `OSTYPE=msys*`/`cygwin*` as Windows. Under WSL pointed at a Windows-native marimo install, `OSTYPE=linux-gnu` and the scripts read `~/.local/state/marimo/servers`, missing the real registry at `$USERPROFILE\.marimo\servers`.

**Fix:** probe a candidate list — XDG path, `~/.marimo/servers`, and (if `$USERPROFILE` is set) a `wslpath`/`cygpath` translation of it — and pick the first directory that has registry files. The `is_windows` flag (used to decide between `kill -0` and an HTTP `/health` probe for liveness) is now inferred from whether the chosen path matches `*/.marimo/servers`, since that's what determines whether the registered PIDs are Windows-native.

## Bug 2 — SSE parser silently drops every event on Windows

`execute-code.sh` reads the event stream with `IFS= read -r line` and matches `event:` / `data:` literally. marimo's HTTP server emits CRLF terminators per the SSE spec; `read -r` strips only the LF, so the trailing `\r` keeps every literal-prefix pattern from matching on Git Bash *and* WSL. Result: stdout / stderr / done events are all dropped — the user sees no output even though the code ran.

**Fix:** one-line `line="${line%$'\r'}"` right after the `read`. Cheap to do unconditionally; works the same on POSIX systems (no CR to strip).

## Testing

- `bash -n` on both scripts (clean).
- On Windows 11 / Git Bash with a live `--no-token` marimo session: `discover-servers.sh` finds the running server, and `execute-code.sh -c "print(1+1)"` returns its output correctly.
- I haven't tested the WSL path translation on a real WSL system — would appreciate a check there. The logic is: if `$USERPROFILE` is set and `wslpath -u` (or `cygpath -u`) is on PATH, append the translated `<USERPROFILE>/.marimo/servers` as a candidate.

## Notes

No behaviour change on Linux/macOS native: the XDG path is checked first and remains the only candidate that has files there. The Windows-native `~/.marimo/servers` path is checked second and is only selected when it actually contains a registry file. Falling through to "no registry found" early-returns `[]` from `discover-servers.sh` exactly as before.