### PR TITLE
Fix claude-code plugin installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Add the marketplace and install the plugin:
 
 ```
 /plugin marketplace add marimo-team/marimo-pair
-/plugin install marimo-pair@marimo-team-marimo-pair
+/plugin install marimo-pair@marimo-pair
 ```
 
 To opt in to auto-updates (recommended), so you always get the latest version:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Add the marketplace and install the plugin:
 To opt in to auto-updates (recommended), so you always get the latest version:
 
 ```
-/plugin → Marketplaces → marimo-team-marimo-pair → Enable auto-update
+/plugin → Marketplaces → marimo-pair → Enable auto-update
 ```
 
 ## FAQ


### PR DESCRIPTION
Closes #44 

README updated to use `@marimo-pair` in the claude plugin installation step bash command.