### PR TITLE
Refocus marimo-pair on notebook semantics

### DIFF
--- a/skills/marimo-pair/SKILL.md
+++ b/skills/marimo-pair/SKILL.md
@@ -1,255 +1,284 @@
 ---
 name: marimo-pair
 description: >-
-  Work inside a running marimo notebook's kernel — execute code, create cells,
-  and build a notebook as an artifact. Use when the user wants to start a
-  marimo notebook or work in an active marimo session.
+  Drive a live marimo notebook as a workspace: run Python in the same kernel
+  the user does, inspect live notebook state, and commit durable notebook
+  changes. Use when the user wants to start a marimo notebook or pair on an
+  active marimo session.
 allowed-tools: Bash(bash **/scripts/discover-servers.sh *), Bash(bash **/scripts/execute-code.sh *), Read
 ---
 
-# marimo Pair Programming Protocol
+marimo is a reactive Python runtime for building reproducible Python programs
+(marimo notebooks). Cells are connected by the variables they define and
+reference. Running a cell re-executes dependents in dataflow order. The active
+runtime holds the kernel namespace, cell state, and dataflow graph. The
+notebook (`.py` file) is the artifact the kernel writes from that state while a
+session is running.
 
-This skill gives you full access to a running marimo notebook. You can read
-cell code, create and edit cells, install packages, run cells, and inspect
-the reactive graph — all programmatically. The user sees results live in their
-browser while you work through bundled scripts or MCP.
+A user interacts with the same runtime via a notebook UI with cells, outputs,
+and widgets.
 
-## Philosophy
+**WARNING. The active runtime is the source of truth.** During a session, you
+SHOULD NOT modify the associated `.py` file directly. File edits WILL NOT reach
+the active kernel or user, and the kernel may overwrite them on save. Use
+`marimo._code_mode` (`cm`) for notebook changes. Reading disk is fine, but
+prefer `ctx.cells[...].code` for current cell code.
 
-marimo notebooks are a dataflow graph — cells are the fundamental unit of
-computation, connected by the variables they define and reference. When a cell
-runs, marimo automatically re-executes downstream cells. You have full access
-to the running notebook.
+## Connect to a Notebook
 
-- **Cells are your main lever.** Use them to break up work and choose how and
-  when to bring the human into the loop. Not every cell needs rich output —
-  sometimes the object itself is enough, sometimes a summary is better.
-  Match the presentation to the intent.
-- **Understand intent first.** When clear, act. When ambiguous, clarify.
-- **Follow existing signal.** Check imports, `pyproject.toml`, existing cells,
-  and `dir(ctx)` before reaching for external tools.
-- **Stay focused.** Build first, polish later — cell names, layout, and styling
-  can wait.
+Use the bundled script (`bash scripts/execute-code.sh`) or MCP
+(`execute_code(...)`) to run Python in a live marimo kernel.
 
-## Prerequisites
-
-### How to invoke marimo
-
-Only servers started with `--no-token` register in the local server registry
-and are auto-discoverable — starting without a token makes discovery easier.
-If a server has a token, set the `MARIMO_TOKEN` environment variable before
-calling the execute script (avoids leaking the token in process listings). The
-right way to invoke marimo depends on context (project
-tooling, global install, sandbox mode). See
-[finding-marimo.md](reference/finding-marimo.md) for the full decision tree.
-
-**Do NOT use `--headless` unless the user asks for it.** Omitting it lets
-marimo auto-open the browser, which is the expected pairing experience. If the
-user explicitly requests headless, offer to open `http://localhost:<port>`
-in their browser (`open` on macOS, `xdg-open` on Linux, `start` on Windows).
-
-## Troubleshooting
-
-### `SyntaxError` or `ImportError` from `execute-code.sh`
-
-Code runs **inside the running marimo kernel** — `execute-code.sh` POSTs it
-over HTTP and never invokes a local Python. So errors here are not caused by
-the local Python version, missing venv, or `uv` vs `pip` — they're problems
-with the code being sent. Fix the code (use a heredoc for anything
-multiline; don't try to one-line compound statements with `;`).
-
-### User keeps getting prompted to allow Bash commands
-
-The skill declares `allowed-tools` in its frontmatter, but Claude Code may
-still prompt for each Bash call. To fix this, the user should add the absolute
-paths to the scripts to their `.claude/settings.json` (project-level) or
-`~/.claude/settings.json` (global):
-
-```json
-{
-  "permissions": {
-    "allow": [
-      "Bash(bash /absolute/path/to/skills/marimo-pair/scripts/discover-servers.sh *)",
-      "Bash(bash /absolute/path/to/skills/marimo-pair/scripts/execute-code.sh *)"
-    ]
-  }
-}
-```
-
-## How to Discover Servers and Execute Code
-
-Two operations: **discover servers** and **execute code**.
-
-| Operation | Script | MCP |
-|-----------|--------|-----|
-| Discover servers | `bash scripts/discover-servers.sh` | `list_sessions()` tool |
-| Execute code | `bash scripts/execute-code.sh -c "code"` | `execute_code(code=..., session_id=...)` tool |
-| Execute code (multiline) | `bash scripts/execute-code.sh <<'EOF'` | same |
-| Execute code (by URL) | `bash scripts/execute-code.sh --url http://localhost:2718 -c "code"` | same (with `url` param) |
-
-Scripts auto-discover sessions from the local server registry. Use
-`--port` to target a specific server when multiple are running,
-`--session` to target a specific session when multiple notebooks are
-open on the same server, or `--url` to skip discovery and connect to a
-server by URL (e.g. `--url http://localhost:2718`). **On Windows, prefer
-direct `--url` when registry discovery is empty** — see the next section
-for why. Set the `MARIMO_TOKEN` env var to authenticate when the server
-has token auth enabled (`--token` flag also works but exposes the token
-in process listings). If the server was started with `--mcp`, you'll
-have MCP tools available as an alternative.
-
-### Discovery finds nothing but the user has a server running?
-
-Only `--no-token` servers are in the registry. If discovery comes up empty,
-the server likely has token auth — ask the user for the token and set it as
-the `MARIMO_TOKEN` environment variable.
-
-On **Windows (Git Bash / MSYS2)**, discovery can also come up empty even for
-a running `--no-token` server. If the user confirms marimo is reachable
-locally, fall back to `--url http://127.0.0.1:<port>` (ask for the port).
-
-### No servers running?
-
-**Always discover before starting.** Background task "completed" notifications
-do not mean the server died — check the output or run discover first.
-
-If no servers are found, read the user's intent — if they want a notebook,
-start one. **Always start marimo as a background task** (using
-`run_in_background` on the Bash tool) so the server automatically gets cleaned
-up when the session ends and doesn't block the conversation. See
-[finding-marimo.md](reference/finding-marimo.md).
-
-If there's no `.py` file yet, pick a descriptive filename based on context
-(e.g., `exploration.py`, `analysis.py`, `dashboard.py`). Don't ask — just
-pick something reasonable.
-
-**Avoid shell escaping issues.** `-c` works for simple one-liners, but for
-multiline code or code with quotes/backticks/`${}`, use a heredoc or a file:
+If the user provides a notebook URL, target it directly:
 
 ```bash
-# heredoc (single-quoted delimiter prevents shell interpolation)
-bash scripts/execute-code.sh <<'EOF'
-import marimo._code_mode as cm
-
-async with cm.get_context() as ctx:
-    ctx.create_cell("x = 1")
-EOF
-
-# file
-bash scripts/execute-code.sh /tmp/code.py
-
-# target a specific port (skips auto-selection when multiple servers run)
-bash scripts/execute-code.sh --port 2718 -c "1 + 1"
+bash scripts/execute-code.sh --url http://localhost:2718 -c "print('connected')"
 ```
 
-## Executing Code
+Use `-c` only for short one-liners. For multiline code or code containing
+quotes, backticks, `$`, or braces, use a single-quoted heredoc:
 
-Every execute-code call runs inside the notebook's kernel. All cell variables
-are in scope — `print(df.head())` just works. Nothing you define persists
-between calls (variables, imports, side-effects all reset), but you can freely
-introspect the notebook: inspect variables, test code snippets, check types
-and shapes. Use this to explore, prototype, and validate before committing
-anything to the notebook — then create cells to persist state and make results
-visible to the user.
-
-To mutate the notebook's dataflow graph — create, edit, and delete cells,
-install packages, and run cells — use `marimo._code_mode`:
-
-```python
+```bash
+bash scripts/execute-code.sh --url http://localhost:2718 <<'PY'
 import marimo._code_mode as cm
 
 async with cm.get_context() as ctx:
-    cid = ctx.create_cell("x = 1")
-    ctx.packages.add("pandas")
+    cid = ctx.create_cell("x = df.head()")
     ctx.run_cell(cid)
+PY
 ```
 
-You **must** use `async with` — without it, operations silently do nothing.
-All `ctx.*` methods are **synchronous** — they queue operations and the
-context manager flushes them on exit. Do **not** `await` them.
+When code already lives in a file, pass the file path:
 
-The kernel supports top-level `await`, so use `async with` directly. Do
-**not** wrap calls in `async def main(): ...` + `asyncio.run(main())` — it's
-unnecessary and easy to get wrong (compound statements like `async with`
-can't follow `def name():` on the same line, so cramming it into a `-c`
-one-liner produces a `SyntaxError`).
+```bash
+bash scripts/execute-code.sh --url http://localhost:2718 /tmp/code.py
+```
 
-**Cells are not auto-executed.** `create_cell` and `edit_cell` are structural
-changes only — use `run_cell` to queue execution.
+If no target is provided, find or start a session. First look for a running
+session with `bash scripts/discover-servers.sh`, MCP `list_sessions()`, or
+local process context. When multiple sessions are possible, target with
+`--url`, `--port`, or `--session`.
 
-`code_mode` is a tested, safe API for notebook mutations — prefer it for all
-structural changes. You also have access to marimo internals from the kernel,
-but treat that as a last resort and only with high confidence after exploration.
+If no server is running and the user wants a notebook, start marimo with
+`--no-token` (and without `--headless`) so it auto-registers for discovery. The
+notebook UI must be open before there is an active session for `execute-code`
+to target. The right way to invoke marimo depends on context (project tooling,
+global install, sandbox mode). See
+[finding-marimo.md](reference/finding-marimo.md) for the full decision tree and
+[execution-context.md](reference/execution-context.md) for scripts, MCP, and
+shell quoting.
 
-**Edit cells through `code_mode`, never the file system. Direct file writes
-are silently lost.** It is tempting to reach for `Edit`/`Write` for a small
-tweak since `edit_cell` requires the full new cell body. Don't — without
-`--watch` (off by default) the kernel never sees those edits and overwrites
-them on its next save, so the user sees nothing. (`Read` on the `.py` is
-okay, but content may lag the live kernel; prefer `ctx.cells[target].code`.)
+## Scratchpad Scope
 
-**UI state lives outside the reactive graph.** Anywidget traitlets can be read
-or set directly (e.g., `slider.value = 5`). For `mo.ui.*` elements, use
-`ctx.set_ui_value(element, new_value)` inside `code_mode`.
+`execute-code` evaluates Python in marimo's scratchpad: a temporary namespace
+with a shallow copy of the kernel globals. Notebook variables are available by
+name, but new top-level bindings and rebindings are discarded after each call.
+In-place mutations to notebook-owned objects can persist because those names
+still reference live objects.
 
-### First Step: Explore the API
+Each call reports stdout and stderr from the scratchpad, plus console output
+from notebook cells it causes to run, including reactive descendants.
 
-The `code_mode` API can change between marimo versions. Explore it at the
-start of each session — dig deeper into anything you're unsure about.
+### Ordinary Python
+
+Use ordinary Python in the scratchpad to inspect variables, sample data, test
+transformations, probe APIs, check imports, and read widget state.
+
+```python
+print(df.head())
+
+x = 10
+print(x)
+```
+
+Here `df` comes from notebook globals, while `x` is a scratchpad-local binding.
+`x` exists for this call only and WILL NOT be added to notebook globals.
+
+### Persist with `cm`
+
+Top-level scratchpad assignments and rebindings are temporary. To persist work,
+including new variables, you MUST submit changes through `marimo._code_mode`
+(`cm`).
+
+`marimo._code_mode` is a PRIVATE, UNSTABLE agent API (note the leading
+underscore). It exists for tools like this skill to drive a live kernel from
+the scratchpad. DO NOT import it from notebook cells, library code, or
+anything a user would run — methods can change or disappear across marimo
+versions and kernels. Treat every `import marimo._code_mode as cm` as
+scratchpad-only.
+
+At session start, inspect what `cm` exposes in the active kernel:
 
 ```python
 import marimo._code_mode as cm
+
 help(cm)
 ```
 
-## Guard Rails
+Open a code-mode context to queue notebook changes.
 
-Skip these and the UI breaks:
+```python
+import marimo._code_mode as cm
 
-- **Install packages via `ctx.packages.add()`, not `uv add` or `pip`.**
-  The code API handles kernel restarts and dependency resolution correctly.
-  Only fall back to external CLIs if the API is unavailable or fails.
-- **Custom widget = anywidget.** For bespoke visual components, use anywidget
-  with HTML/CSS/JS. Composed `mo.ui` is fine for simple forms and controls.
-  See [rich-representations.md](reference/rich-representations.md).
-- **NEVER `Edit`, `Write`, or `NotebookEdit` the notebook `.py` file while a
-  session is running. Direct writes are silently destroyed and never reach the
-  user.** marimo only watches the file with `--watch`, which is off by
-  default. Without it, the kernel doesn't pick up file edits — and on its
-  next save, the kernel writes its own state and clobbers yours. The user sees
-  no change, you think the work landed, and the bug is invisible. Always use
-  `ctx.edit_cell(target, code=...)` with the full new cell body — even for a
-  one-character change. (`Read` is allowed, but disk content may lag the live
-  kernel; for the current truth prefer `ctx.cells[target].code`.)
-- **No temp-file deps in cells.** `pathlib.Path("/tmp/...")` in cell code is a bug.
-- **Avoid empty cells.** Prefer `edit_cell` into existing empty cells rather
-  than creating new ones. Clean up any cells that end up empty after edits.
-- **Don't worry about cell names.** Most cells don't need explicit names —
-  see [notebook-improvements.md](reference/notebook-improvements.md#cell-names).
+async with cm.get_context() as ctx:
+    cid = ctx.create_cell("x = df.head()")
+    ctx.run_cell(cid)
+```
 
-## Widgets and Reactivity
+The scratchpad supports top-level async code. Use `async with` directly;
+wrapping it in `asyncio.run(...)` is unnecessary and can conflict with the
+kernel's event loop.
 
-Anywidget state (traitlets) lives outside marimo's reactive graph. To hook a
-widget trait into the graph, pick one strategy per widget — never mix them:
+After this block exits and the new cell runs, `x` is notebook state. Later
+scratchpad calls can read `x` by name. Code later in the same scratchpad call
+should read `ctx.globals["x"]`, because the scratchpad namespace was copied
+before the cell ran.
 
-- **`mo.state` + `.observe()`** — you pick specific traits to bridge. Default choice.
-- **`mo.ui.anywidget()`** — wraps all synced traits into one reactive `.value`. Convenient but coarser.
+Inside the context, queued mutation methods are synchronous. Call them
+directly; do not `await` them. Each call queues an operation for marimo to
+apply when the context exits normally. If the block raises, the queue is
+discarded.
 
-Read [rich-representations.md](reference/rich-representations.md) before wiring either.
+On clean exit, marimo applies packages, validates and applies structural cell
+changes, runs queued cells, then may run dependents. Validation is only
+structural since queued cell runs can still error. `create_cell` and
+`edit_cell` change notebook structure only. Use `run_cell` to execute.
 
-## Keep in Mind
+## Marimo Rules
 
-- **The user is editing too.** The notebook can change between your calls —
-  re-inspect notebook state if it's been a while since you last looked.
-- **Deletions are destructive.** Deleting a cell removes its variables from
-  kernel memory — restoring means recreating the cell and re-running it and
-  its dependents. If intent seems ambiguous, ask first.
-- **Installing packages changes the project.** `ctx.packages.add()` adds
-  real dependencies — confirm when it's not obvious from context.
+marimo imposes a small contract on notebook code so it can keep the notebook as
+a directed acyclic graph (DAG):
+
+- **No cycles** - cells cannot depend on each other in a cycle.
+- **No public redefinitions across cells** - each name has one owning cell.
+- **No wildcard imports** - `import *` prevents static analysis of definitions.
+
+These rules keep the kernel, UI, and saved artifact consistent.
+
+When `cm` submits a cell body, marimo parses its top-level definitions and
+references. A top-level name enters the graph unless it is private with a
+leading underscore.
+
+```python
+# Public definitions: values, total, i, value, mean
+values = np.array([1, 2, 3])
+total = 0
+for i, value in enumerate(values):
+    total += value
+mean = total / len(values)
+mean
+```
+
+```python
+# Public definition: mean
+_values = np.array([1, 2, 3])
+_total = 0
+for _i, _value in enumerate(_values):
+    _total += _value
+mean = _total / len(_values)
+mean
+```
+
+Use private names for intermediates that no other cell should read. Public
+names define the notebook-level dataflow. If a `cm` edit violates the contract,
+marimo rejects the structural change and returns the validation error.
+
+## The Notebook's Shape
+
+A notebook is an ordered collection of cells. `ctx.cells` is the document view
+and `ctx.graph` is the dataflow view.
+
+```python
+for cell in ctx.cells:
+    cell  # .id, .code, .name, .config, .status, .errors
+
+ctx.cells["setup"]         # by name
+ctx.cells[0]               # by position
+list(ctx.cells.keys())     # all IDs, in notebook order
+```
+
+Cell IDs are opaque strings which can be queried from the notebook or captured
+from `cm` return values:
+
+```python
+cid = ctx.create_cell("df = pd.read_csv('data.csv')")
+print(cid)   # e.g. 'Hbol'
+```
+
+Alternatively, cells can be assigned and referenced by `name`. The graph can be
+used to understand its role in the dataflow.
+
+```python
+for cid, impl in ctx.graph.cells.items():
+    impl  # .defs, .refs   (sets of public names)
+
+ctx.graph.descendants(cid)   # cells that re-run when this one changes
+ctx.graph.ancestors(cid)     # cells this one depends on
+```
+
+In marimo, deletes are *destructive* so it can be useful to query the
+descendants prior to deleting to understand it's impact.
+
+## Writing Notebook Changes
+
+The graph contract keeps marimo able to run and save the notebook. Passing
+those checks alone does not guarantee a useful artifact. Committed cells should
+still be readable, rerunnable, and editable.
+
+Make durable edits that reuse the notebook's existing names, imports,
+dependencies, and UI model. Don't be lazy. Avoid one-off workarounds that pass
+`cm` validation but leave a brittle notebook.
+
+### Cell Bodies
+
+Submit the code that belongs in the cell.
+
+- **Submit cell contents** - `create_cell` and `edit_cell` take cell contents,
+  not saved-file `@app.cell` wrappers.
+- **Read before replacing** - for now, another editor may change a cell between
+  scratchpad calls. Before `edit_cell`, read the current body from
+  `ctx.cells[...]` and submit the full replacement.
+- **Reuse notebook imports** - if `np` already exists, use it or edit the owning
+  import cell. DO NOT add `import numpy as _np` just to bypass the graph.
+- **Define public names intentionally** - use public names for values later
+  cells should reference. Use private `_name` bindings or function locals for
+  same-cell intermediates.
+- **Run cells deliberately** - `create_cell` and `edit_cell` change structure
+  only. Queue `ctx.run_cell(...)` when the cell should execute.
+
+### Prefer `cm`-Managed Changes
+
+Use `cm` APIs when they exist. Avoid direct file edits, shell package commands,
+and scratchpad-only state for changes that should persist.
+
+- **Do not edit the `.py` artifact** - DO NOT use `Edit`, `Write`, or
+  `NotebookEdit` on the notebook file during a live session. Use
+  `ctx.edit_cell(...)` even for small changes.
+- **Manage packages through `cm`** - use `ctx.packages.add()` or
+  `ctx.packages.remove()` instead of direct `uv` or `pip`; confirm
+  non-obvious dependency changes.
+- **Avoid transient paths** - persisted cells should not depend on `/tmp/...`
+  unless the work is intentionally transient.
+- **Delete deliberately** - deleting a cell removes globals it defines. Reuse
+  empty cells when convenient and delete cells left empty after edits.
+
+### UI and Widgets
+
+Inspect the object before changing it. Different UI objects update through
+different paths.
+
+- **Set `mo.ui.*` through `cm`** - use `ctx.set_ui_value(element, value)` inside
+  `cm.get_context()`.
+- **Set anywidget traitlets directly** - synced traitlets are Python
+  attributes, for example `widget.value = 5`.
+
+For designing custom visual or interactive output, see
+[rich-representations.md](reference/rich-representations.md).
 
 ## References
 
-- [finding-marimo.md](reference/finding-marimo.md) — how to find and invoke the right marimo
-- [gotchas.md](reference/gotchas.md) — cached module proxies and other traps
+- [execution-context.md](reference/execution-context.md) — scripts, MCP, auth, startup, and shell quoting
+- [finding-marimo.md](reference/finding-marimo.md) — choosing the right marimo invocation
+- [gotchas.md](reference/gotchas.md) — cached module proxies and notebook traps
 - [rich-representations.md](reference/rich-representations.md) — custom widgets and visualizations
 - [notebook-improvements.md](reference/notebook-improvements.md) — improving existing notebooks

--- a/skills/marimo-pair/reference/execution-context.md
+++ b/skills/marimo-pair/reference/execution-context.md
@@ -1,0 +1,62 @@
+# Connection Troubleshooting
+
+Use this reference when `execute-code.sh` or MCP cannot reach the intended
+marimo session, cannot select a session, or fails because code was passed
+incorrectly.
+
+## Targeting
+
+Use explicit targets when possible.
+
+- `--url` connects to a known marimo server or notebook URL.
+- `--port` selects a local marimo server from the registry.
+- `--session` selects one notebook session on a server.
+
+If multiple servers or sessions are available, do not guess. Ask for the URL or
+session, or inspect local context.
+
+## Auth
+
+For token-authenticated servers, prefer `MARIMO_TOKEN`.
+
+```bash
+MARIMO_TOKEN=... bash scripts/execute-code.sh --url http://localhost:2718 -c "1 + 1"
+```
+
+`--token` also works, but may expose the token in process listings. If both are
+present, `--token` overrides `MARIMO_TOKEN`. The script sends the token as
+`Authorization: Bearer ...` on session discovery and code execution requests.
+
+## Quoting
+
+Use `-c` only for short one-liners. Use a single-quoted heredoc or file input
+for multiline code or shell-sensitive characters.
+
+```bash
+bash scripts/execute-code.sh --url http://localhost:2718 <<'PY'
+print(df.head())
+PY
+```
+
+```bash
+bash scripts/execute-code.sh --url http://localhost:2718 /tmp/code.py
+```
+
+## Common Script Errors
+
+- **No running marimo instances found** - use an explicit `--url`, or start
+  marimo with the project's normal tooling.
+- **Multiple instances found** - rerun with `--port` or `--url`.
+- **No active sessions on the server** - open the notebook in the browser or
+  provide `--session`.
+- **Multiple sessions on server** - rerun with `--session`.
+- **Failed to connect** - check the URL, token, and whether the server is still
+  running.
+- **SyntaxError** - the submitted Python was malformed; use a heredoc or file.
+- **ImportError** - diagnose in the notebook kernel. Install packages through
+  `cm` when needed.
+
+## Starting marimo
+
+Discover first. If no server is running and the user wants a notebook, use
+[finding-marimo.md](finding-marimo.md).

--- a/skills/marimo-pair/reference/finding-marimo.md
+++ b/skills/marimo-pair/reference/finding-marimo.md
@@ -9,6 +9,11 @@ calling the execute script (avoids leaking the token in process listings).
 marimo edit notebook.py --no-token [--sandbox]
 ```
 
+Start marimo in edit mode without `--headless` unless the user asks for a
+headless server. The notebook UI must be open in a browser before marimo has an
+active session for `execute-code` to target. If running headless, give the user
+the local URL and wait for them to open it before executing code.
+
 How you invoke `marimo` depends on context — find the right way to run it.
 
 ## Inside a Python project

--- a/skills/marimo-pair/reference/rich-representations.md
+++ b/skills/marimo-pair/reference/rich-representations.md
@@ -11,9 +11,9 @@ users *see* their data in ways that tables and numbers never will. marimo
 is an environment where users create their own views, not just consume
 library charts. Help them imagine what's possible, then build it.
 
-**Use the modern web.** Always use the most modern HTML, CSS, and JavaScript
-available. If a feature is supported in every browser, even if only the most
-recent version, use it.
+**Use modern web APIs.** Models may default to older browser patterns; prefer
+modern HTML, CSS, and JavaScript that are supported in current browsers. Avoid
+build steps unless the task clearly needs them.
 
 **Prefer compact output.** marimo clips cell output at ~610px and scrolls.
 Avoid hitting that limit; if you need more space, manage your own scrolling
@@ -28,11 +28,12 @@ and views. Don't over-engineer.
 
 | Need | Approach |
 |------|----------|
-| Default for any custom output | **anywidget** — even display-only; you get layout control and can add interaction later |
-| Trivial one-off static HTML | `_display_()` or `mo.Html` — only when an anywidget is truly overkill |
-| Single built-in control used as-is (slider, dropdown) | `mo.ui.*` |
+| Custom output or interaction | **anywidget** — flexible enough to grow from display-only to interactive |
+| Tiny static HTML representation | `_display_()` or `mo.Html` |
+| Built-in control used as-is (slider, dropdown) | `mo.ui.*` |
 
-When in doubt, build an anywidget.
+For custom representations, prefer anywidget unless the output is clearly a
+small static one-off.
 
 ## anywidget
 
@@ -174,10 +175,10 @@ seconds = get_seconds()
 mo.md(f"Timer is at **{seconds}s** — {'running' if seconds > 0 else 'stopped'}")
 ```
 
-This pattern is always the same: `mo.state(widget.trait)` for the initial
-value, `.observe()` on the specific trait name, read with the getter in a
+The common pattern is `mo.state(widget.trait)` for the initial value,
+`.observe()` on the specific trait name, and reading with the getter in a
 downstream cell. See [Reactive anywidgets](#reactive-anywidgets-in-marimo)
-for the full rules.
+for the details.
 
 ### CDN dependencies
 
@@ -266,8 +267,8 @@ print(timer.seconds)    # read
 timer.seconds = 0       # set — frontend updates automatically
 ```
 
-`mo.ui.*` elements need `set_ui_element_value`; anywidgets use direct
-assignment.
+`mo.ui.*` elements need `ctx.set_ui_value(...)` from code mode; anywidgets use
+direct assignment.
 
 ## `_display_()` protocol
 


### PR DESCRIPTION
The previous SKILL conflated marimo's runtime model with host plumbing and a appended list of don'ts. The rewrite leads with what the kernel actually does (dataflow graph, plus a scratchpad namespace distinct from notebook globals) so agents reach for `cm` to persist work instead of learning the rule by tripping a guard rail.

Discovery, targeting, auth, and shell quoting move to `reference/execution-context.md`; the main skill is about working inside a notebook, not one host's process model. Tone is less categorical throughout: recommendations name the tradeoff instead of flatly forbidding the alternative.