### PR TITLE
Add Codex plugin marketplace support

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,12 @@
+{
+  "name": "marimo-pair",
+  "interface": { "displayName": "marimo pair" },
+  "plugins": [
+    {
+      "name": "marimo-pair",
+      "source": { "source": "local", "path": "./" },
+      "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
       "name": "marimo-pair",
       "source": { "source": "local", "path": "./" },
       "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },
-      "category": "Productivity"
+      "category": "Education & Research"
     }
   ]
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "marimo-pair",
+  "version": "0.0.15",
+  "description": "Pair programming protocol for marimo notebooks",
+  "author": { "name": "marimo-team", "email": "contact@marimo.io" },
+  "repository": "https://github.com/marimo-team/marimo-pair",
+  "skills": "./skills/"
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,11 +40,14 @@ jobs:
           jq --arg v "$new" '.metadata.version = $v' .claude-plugin/marketplace.json > tmp.json
           mv tmp.json .claude-plugin/marketplace.json
 
+          jq --arg v "$new" '.version = $v' .codex-plugin/plugin.json > tmp.json
+          mv tmp.json .codex-plugin/plugin.json
+
       - name: Commit and tag
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .claude-plugin/marketplace.json
+          git add .claude-plugin/marketplace.json .codex-plugin/plugin.json
           git commit -m "Release v${{ steps.bump.outputs.version }}"
           git tag "v${{ steps.bump.outputs.version }}"
           git push origin main --tags


### PR DESCRIPTION
Adds Codex plugin marketplace support, mirroring the existing `.claude-plugin/` setup.

Install is a one-liner, not the interactive browser:

    codex plugin marketplace add marimo-team/marimo-pair
    codex plugin add marimo-pair@marimo-pair
    codex plugin marketplace upgrade marimo-pair

Verified end to end from this branch: both skills install, plugin enables, upgrade
works. Release workflow bumps `.codex-plugin/plugin.json` alongside the Claude manifest.