### PR TITLE
feat: marimo-lens integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ paths to the scripts from the installed skill and add them to your
   "permissions": {
     "allow": [
       "Bash(bash /path/to/skills/marimo-pair/scripts/discover-servers.sh *)",
-      "Bash(bash /path/to/skills/marimo-pair/scripts/execute-code.sh *)"
+      "Bash(bash /path/to/skills/marimo-pair/scripts/execute-code.sh *)",
+      "Bash(bash /path/to/skills/marimo-pair/scripts/lens-context.sh *)"
     ]
   }
 }

--- a/skills/marimo-pair/SKILL.md
+++ b/skills/marimo-pair/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   the user does, inspect live notebook state, and commit durable notebook
   changes. Use when the user wants to start a marimo notebook or pair on an
   active marimo session.
-allowed-tools: Bash(bash **/scripts/discover-servers.sh *), Bash(bash **/scripts/execute-code.sh *), Read
+allowed-tools: Bash(bash **/scripts/discover-servers.sh *), Bash(bash **/scripts/execute-code.sh *), Bash(bash **/scripts/lens-context.sh *), Read
 ---
 
 marimo is a reactive Python runtime for building reproducible Python programs
@@ -69,6 +69,43 @@ ignores the inline dependencies. See
 [finding-marimo.md](reference/finding-marimo.md) for the full decision tree and
 [execution-context.md](reference/execution-context.md) for scripts, MCP, and
 shell quoting.
+
+## Ground Requests with Lens
+
+After connecting, run one Lens scan:
+
+```bash
+bash scripts/lens-context.sh --url http://localhost:2718 scan
+```
+
+The command reports `absent` when `marimo-lens` is unavailable or the notebook
+has no live Lens object. Continue with the ordinary Pair workflow and do not
+retry Lens during the same request. A later notebook state change or an
+explicit user request starts a new scan.
+
+A `ready` result identifies the current selection, its output cell, an
+optional note, and compact graph metadata. Treat the current selection as the
+likely referent for phrases such as "this cell". Use the normal code-mode
+workflow to inspect source and graph neighbors as the task requires. Load Lens
+text or image evidence when the request depends on information absent from the
+scan.
+
+Before the first notebook mutation, mark the primary cell with `activity`.
+Choose one short contextual label, such as `On it`, `Checking`, or `Updating`,
+and keep it for the run. Activity remains visible through edits and execution.
+
+After the mutation call completes, use a fresh call to verify that every
+claimed cell is `idle` and that the requested output is current. Resolve all
+selections addressed by the same verified change in one command. Call
+`reveal` last to bring the result into view and end activity. Pass the exact
+selection IDs, revision, and Lens token returned by the scan. Leave activity
+and selections open while execution or verification is incomplete.
+
+A reopened selection can include the prior resolution summary so follow-up
+work starts with that receipt.
+
+Read [marimo-lens.md](reference/marimo-lens.md) for commands, progressive
+context loading, image cleanup, and result handling.
 
 ## Scratchpad Scope
 
@@ -293,3 +330,5 @@ For designing custom visual or interactive output, see
 - [gotchas.md](reference/gotchas.md) — name redefinition, cached module proxies, and notebook traps
 - [rich-representations.md](reference/rich-representations.md) — custom widgets and visualizations
 - [notebook-improvements.md](reference/notebook-improvements.md) — improving existing notebooks
+- [marimo-lens.md](reference/marimo-lens.md): selected outputs, progressive
+  context, images, and completion

--- a/skills/marimo-pair/SKILL.md
+++ b/skills/marimo-pair/SKILL.md
@@ -64,13 +64,13 @@ If no server is running and the user wants a notebook, start marimo with
 notebook UI must be open before there is an active session for `execute-code`
 to target. The right way to invoke marimo depends on context (project tooling,
 global install, sandbox mode). If the notebook file contains a PEP 723 `#
-/// script` header, it MUST be opened with `--sandbox` — otherwise marimo
+/// script` header, it MUST be opened with `--sandbox`, or marimo
 ignores the inline dependencies. See
 [finding-marimo.md](reference/finding-marimo.md) for the full decision tree and
 [execution-context.md](reference/execution-context.md) for scripts, MCP, and
 shell quoting.
 
-## Ground Requests with Lens
+## Optional Lens Context
 
 After connecting, run one Lens scan:
 
@@ -90,16 +90,23 @@ workflow to inspect source and graph neighbors as the task requires. Load Lens
 text or image evidence when the request depends on information absent from the
 scan.
 
+For visual or spatial work, use `scan --image cell` and open the returned path.
+One cell image contains every open mark on that output.
+
 Before the first notebook mutation, mark the primary cell with `activity`.
-Choose one short contextual label, such as `On it`, `Checking`, or `Updating`,
-and keep it for the run. Activity remains visible through edits and execution.
+Choose a short, free-form label from the user's intent. `On it...`,
+`Tracing this...`, and `Tidying the chart...` illustrate the voice. Compose
+any equivalent phrase, put the concrete action in the message, and keep the
+label for the run. Activity remains visible through edits and execution.
 
 After the mutation call completes, use a fresh call to verify that every
-claimed cell is `idle` and that the requested output is current. Resolve all
-selections addressed by the same verified change in one command. Call
-`reveal` last to bring the result into view and end activity. Pass the exact
-selection IDs, revision, and Lens token returned by the scan. Leave activity
-and selections open while execution or verification is incomplete.
+claimed cell is `idle` and that the requested output is current. Open a fresh
+image after a visual change. Resolve all selections addressed by the same
+verified change in one command. Call `reveal` last to bring the result into
+view and end activity. Pass the exact selection IDs, revision, and Lens token
+returned by the scan. Remove every returned `imageDir` after the final image
+read. Leave activity and selections open while execution or verification is
+incomplete.
 
 A reopened selection can include the prior resolution summary so follow-up
 work starts with that receipt.
@@ -142,7 +149,7 @@ including new variables, you MUST submit changes through `marimo._code_mode`
 `marimo._code_mode` is a PRIVATE, UNSTABLE agent API (note the leading
 underscore). It exists for tools like this skill to drive a live kernel from
 the scratchpad. DO NOT import it from notebook cells, library code, or
-anything a user would run — methods can change or disappear across marimo
+anything a user would run. Methods can change or disappear across marimo
 versions and kernels. Treat every `import marimo._code_mode as cm` as
 scratchpad-only.
 
@@ -164,8 +171,8 @@ async with cm.get_context() as ctx:
     ctx.run_cell(cid)
 ```
 
-The scratchpad supports top-level async code. Use `async with` directly;
-wrapping it in `asyncio.run(...)` is unnecessary and can conflict with the
+The scratchpad supports top-level async code. Use `async with` directly.
+Wrapping it in `asyncio.run(...)` is unnecessary and can conflict with the
 kernel's event loop.
 
 After this block exits and the new cell runs, `x` is notebook state. Later
@@ -174,7 +181,7 @@ should read `ctx.globals["x"]`, because the scratchpad namespace was copied
 before the cell ran.
 
 Inside the context, queued mutation methods are synchronous. Call them
-directly; do not `await` them. Each call queues an operation for marimo to
+directly and do not `await` them. Each call queues an operation for marimo to
 apply when the context exits normally. If the block raises, the queue is
 discarded.
 
@@ -288,7 +295,7 @@ Submit the code that belongs in the cell.
   cells should reference. Use private `_name` bindings or function locals for
   same-cell intermediates.
 - **Define each public name once** - a public name has one owning cell.
-  Reassigning it in another cell fails with `Multiply-defined names`; edit the
+  Reassigning it in another cell fails with `Multiply-defined names`. Edit the
   owning cell or give the result a new name. See
   [gotchas.md](reference/gotchas.md).
 - **Run cells deliberately** - `create_cell` and `edit_cell` change structure
@@ -303,7 +310,7 @@ and scratchpad-only state for changes that should persist.
   `NotebookEdit` on the notebook file during a live session. Use
   `ctx.edit_cell(...)` even for small changes.
 - **Manage packages through `cm`** - use `ctx.packages.add()` or
-  `ctx.packages.remove()` instead of direct `uv` or `pip`; confirm
+  `ctx.packages.remove()` instead of direct `uv` or `pip`. Confirm
   non-obvious dependency changes.
 - **Avoid transient paths** - persisted cells should not depend on `/tmp/...`
   unless the work is intentionally transient.
@@ -325,10 +332,10 @@ For designing custom visual or interactive output, see
 
 ## References
 
-- [execution-context.md](reference/execution-context.md) — scripts, MCP, auth, startup, and shell quoting
-- [finding-marimo.md](reference/finding-marimo.md) — choosing the right marimo invocation
-- [gotchas.md](reference/gotchas.md) — name redefinition, cached module proxies, and notebook traps
-- [rich-representations.md](reference/rich-representations.md) — custom widgets and visualizations
-- [notebook-improvements.md](reference/notebook-improvements.md) — improving existing notebooks
+- [execution-context.md](reference/execution-context.md): scripts, MCP, auth, startup, and shell quoting
+- [finding-marimo.md](reference/finding-marimo.md): choosing the right marimo invocation
+- [gotchas.md](reference/gotchas.md): name redefinition, cached module proxies, and notebook traps
+- [rich-representations.md](reference/rich-representations.md): custom widgets and visualizations
+- [notebook-improvements.md](reference/notebook-improvements.md): improving existing notebooks
 - [marimo-lens.md](reference/marimo-lens.md): selected outputs, progressive
   context, images, and completion

--- a/skills/marimo-pair/SKILL.md
+++ b/skills/marimo-pair/SKILL.md
@@ -64,7 +64,7 @@ If no server is running and the user wants a notebook, start marimo with
 notebook UI must be open before there is an active session for `execute-code`
 to target. The right way to invoke marimo depends on context (project tooling,
 global install, sandbox mode). If the notebook file contains a PEP 723 `#
-/// script` header, it MUST be opened with `--sandbox`, or marimo
+/// script` header, it MUST be opened with `--sandbox` — otherwise marimo
 ignores the inline dependencies. See
 [finding-marimo.md](reference/finding-marimo.md) for the full decision tree and
 [execution-context.md](reference/execution-context.md) for scripts, MCP, and
@@ -149,7 +149,7 @@ including new variables, you MUST submit changes through `marimo._code_mode`
 `marimo._code_mode` is a PRIVATE, UNSTABLE agent API (note the leading
 underscore). It exists for tools like this skill to drive a live kernel from
 the scratchpad. DO NOT import it from notebook cells, library code, or
-anything a user would run. Methods can change or disappear across marimo
+anything a user would run — methods can change or disappear across marimo
 versions and kernels. Treat every `import marimo._code_mode as cm` as
 scratchpad-only.
 
@@ -171,8 +171,8 @@ async with cm.get_context() as ctx:
     ctx.run_cell(cid)
 ```
 
-The scratchpad supports top-level async code. Use `async with` directly.
-Wrapping it in `asyncio.run(...)` is unnecessary and can conflict with the
+The scratchpad supports top-level async code. Use `async with` directly;
+wrapping it in `asyncio.run(...)` is unnecessary and can conflict with the
 kernel's event loop.
 
 After this block exits and the new cell runs, `x` is notebook state. Later
@@ -181,7 +181,7 @@ should read `ctx.globals["x"]`, because the scratchpad namespace was copied
 before the cell ran.
 
 Inside the context, queued mutation methods are synchronous. Call them
-directly and do not `await` them. Each call queues an operation for marimo to
+directly; do not `await` them. Each call queues an operation for marimo to
 apply when the context exits normally. If the block raises, the queue is
 discarded.
 
@@ -295,7 +295,7 @@ Submit the code that belongs in the cell.
   cells should reference. Use private `_name` bindings or function locals for
   same-cell intermediates.
 - **Define each public name once** - a public name has one owning cell.
-  Reassigning it in another cell fails with `Multiply-defined names`. Edit the
+  Reassigning it in another cell fails with `Multiply-defined names`; edit the
   owning cell or give the result a new name. See
   [gotchas.md](reference/gotchas.md).
 - **Run cells deliberately** - `create_cell` and `edit_cell` change structure
@@ -310,7 +310,7 @@ and scratchpad-only state for changes that should persist.
   `NotebookEdit` on the notebook file during a live session. Use
   `ctx.edit_cell(...)` even for small changes.
 - **Manage packages through `cm`** - use `ctx.packages.add()` or
-  `ctx.packages.remove()` instead of direct `uv` or `pip`. Confirm
+  `ctx.packages.remove()` instead of direct `uv` or `pip`; confirm
   non-obvious dependency changes.
 - **Avoid transient paths** - persisted cells should not depend on `/tmp/...`
   unless the work is intentionally transient.
@@ -332,10 +332,10 @@ For designing custom visual or interactive output, see
 
 ## References
 
-- [execution-context.md](reference/execution-context.md): scripts, MCP, auth, startup, and shell quoting
-- [finding-marimo.md](reference/finding-marimo.md): choosing the right marimo invocation
-- [gotchas.md](reference/gotchas.md): name redefinition, cached module proxies, and notebook traps
-- [rich-representations.md](reference/rich-representations.md): custom widgets and visualizations
-- [notebook-improvements.md](reference/notebook-improvements.md): improving existing notebooks
-- [marimo-lens.md](reference/marimo-lens.md): selected outputs, progressive
+- [execution-context.md](reference/execution-context.md) — scripts, MCP, auth, startup, and shell quoting
+- [finding-marimo.md](reference/finding-marimo.md) — choosing the right marimo invocation
+- [gotchas.md](reference/gotchas.md) — name redefinition, cached module proxies, and notebook traps
+- [rich-representations.md](reference/rich-representations.md) — custom widgets and visualizations
+- [notebook-improvements.md](reference/notebook-improvements.md) — improving existing notebooks
+- [marimo-lens.md](reference/marimo-lens.md) — selected outputs, progressive
   context, images, and completion

--- a/skills/marimo-pair/reference/marimo-lens.md
+++ b/skills/marimo-pair/reference/marimo-lens.md
@@ -1,0 +1,194 @@
+# Work with marimo Lens
+
+marimo Lens records the output and location a user points at. An optional note
+adds intent. Pair uses that attention to resolve references such as "this
+cell", inspect the relevant notebook graph, and report the verified result
+back in the notebook.
+
+## Start with one scan
+
+Scan after connecting:
+
+```bash
+bash scripts/lens-context.sh --url http://localhost:2718 scan
+```
+
+The entrypoint owns Lens availability detection. When `marimo-lens` is
+unavailable or the notebook has no live Lens object, it exits successfully
+with:
+
+```json
+{"action":"scan","result":{"status":"absent"}}
+```
+
+Continue with the ordinary Pair workflow and do not retry Lens during the same
+request. Scan again after the notebook state changes or the user explicitly
+asks.
+
+A `ready` result contains bounded selection data:
+
+```json
+{
+  "action": "scan",
+  "result": {
+    "status": "ready",
+    "lensToken": "F3n...",
+    "revision": 8,
+    "lens": {"variable": "lens"},
+    "selectionCount": 1,
+    "current": {
+      "id": "243110...",
+      "label": "S1",
+      "outputCellId": "BYtC",
+      "note": {"text": "Use completed orders", "truncated": false}
+    },
+    "currentCell": {
+      "id": "BYtC",
+      "status": "available",
+      "defs": ["revenue"],
+      "refs": ["orders"]
+    }
+  }
+}
+```
+
+Use `current` as the likely referent for "this", "here", or "the selected
+cell". The user's current request has priority over an older note. An explicit
+cell ID or variable in the request has priority over an inferred referent.
+
+Keep the scan's stable selection ID, revision, and Lens token together. Later
+commands use them to avoid acting on selection state that changed during the
+task.
+
+## Load context progressively
+
+The selected output cell is the semantic notebook target. Read that cell
+through `marimo._code_mode`, then inspect ancestors or descendants only when
+the task needs them:
+
+```python
+import marimo._code_mode as cm
+
+async with cm.get_context() as ctx:
+    cell = ctx.graph.cells["BYtC"]
+    print(cell.code)
+    print(ctx.graph.ancestors("BYtC"))
+```
+
+The scan, selected cell, note, DOM hint, and dataflow graph are the default
+context. Load standalone Lens text when those sources are insufficient:
+
+```bash
+bash scripts/lens-context.sh --url http://localhost:2718 \
+  text --revision 8 --lens-token 'F3n...'
+```
+
+Read the packet from `.result.text`. It can be substantially larger than the
+scan, so keep this step lazy.
+
+## Use images when pixels carry evidence
+
+A selection image preserves the pixels and annotation captured when the user
+pointed:
+
+```bash
+bash scripts/lens-context.sh --url http://localhost:2718 \
+  image --selection-id '243110...' \
+  --revision 8 --lens-token 'F3n...'
+```
+
+Capture the current full output of a cell when visual verification depends on
+its latest rendering:
+
+```bash
+bash scripts/lens-context.sh --url http://localhost:2718 \
+  image --cell BYtC --revision 8 --lens-token 'F3n...'
+```
+
+The cell image contains every open Lens point and region on that output in one
+current raster. Prefer it when several relevant selections share a cell. Use a
+selection image when the pixels captured at the time of one selection are
+material to the request.
+
+Both commands return image metadata and a private temporary `path`. The cell
+result includes `selectionCount`, which reports how many marks were drawn.
+Read the file with the agent client's image tool. The JSON packet contains no
+image bytes. Remove the returned directory after the task:
+
+```bash
+bash scripts/lens-context.sh cleanup-images \
+  '/tmp/marimo-pair-lens.A1b2c3'
+```
+
+Use text and graph evidence for text-only models. An unavailable image does
+not invalidate its cell-backed selection.
+
+## Show progress in the notebook
+
+Mark the primary cell before focused work:
+
+```bash
+bash scripts/lens-context.sh --url http://localhost:2718 \
+  activity --cell BYtC --lens-token 'F3n...' \
+  --label "On it" \
+  --message "Updating the aggregation used by this output"
+```
+
+Activity is transient and does not scroll. It stays visible while the cell
+rerenders and remains active until another activity or a reveal replaces it.
+Choose one short label for the run. The message names the concrete work.
+
+Keep activity visible while applying edits, running explicitly requested
+cells, waiting for reactive descendants, and correcting execution errors.
+After the mutation call completes, inspect the target and affected cells in a
+fresh execution call. A cell is complete when its status is `idle`. Run a
+relevant stale downstream cell explicitly when the notebook uses lazy
+execution.
+
+## Resolve and reveal completed attention
+
+Resolve a selection after the notebook edit is committed, affected cells have
+run, and the requested result is verified:
+
+```bash
+bash scripts/lens-context.sh --url http://localhost:2718 \
+  resolve '243110...' '8b20f4...' --revision 8 --lens-token 'F3n...' \
+  --summary "Updated the aggregation and verified the chart."
+```
+
+One resolve command commits every supplied selection together. Use one shared
+summary when one verified change addresses several annotations. Issue separate
+commands when the selections require distinct explanations.
+
+The summary is a concise receipt for the user. If the user requests changes,
+Lens can reopen a selection. A later scan exposes the prior receipt as
+`current.previousResolution`.
+
+Reveal the primary result after resolution:
+
+```bash
+bash scripts/lens-context.sh --url http://localhost:2718 \
+  reveal --cell BYtC --lens-token 'F3n...' \
+  --message "Updated the aggregation and verified the output"
+```
+
+Reveal scrolls once, highlights the cell, and ends activity. Use one primary
+cell. Mention secondary cells in the normal response.
+
+Leave the selection open when work is partial or verification fails. On
+`revision-conflict` or an error with code `lens_changed`, scan again and
+confirm that the current selection still grounds the completed work before
+retrying.
+
+## Result handling
+
+- `ready`: Continue from the returned Lens context.
+- `absent`: Continue with the ordinary Pair workflow.
+- `ambiguous`: Ask the user to leave one displayed Lens instance, then scan
+  again.
+- `selection-not-found`: Scan again because the selection changed or was
+  removed.
+- `image-unavailable`: Continue from text and graph evidence.
+- `capture-timeout`: Continue from text or retry once after the output settles.
+- `revision-conflict` or error code `lens_changed`: Scan again before acting.
+- `error`: Report the returned code and keep unresolved attention open.

--- a/skills/marimo-pair/reference/marimo-lens.md
+++ b/skills/marimo-pair/reference/marimo-lens.md
@@ -2,30 +2,54 @@
 
 marimo Lens records the output and location a user points at. An optional note
 adds intent. Pair uses that attention to resolve references such as "this
-cell", inspect the relevant notebook graph, and report the verified result
-back in the notebook.
+cell", inspect the relevant notebook graph, and report a verified result in the
+notebook.
 
-## Start with one scan
+Resolve every helper path from the directory containing the loaded
+`SKILL.md`. Run the examples from that directory or replace `scripts/` with its
+absolute path.
 
-Scan after connecting:
+## Ground one request
+
+When the user delegates intent to current Lens selections and the client can
+read images, use one grouped cell image in the connection probe:
+
+```bash
+bash scripts/lens-context.sh --url http://localhost:2718 \
+  scan --image cell
+```
+
+This is the efficient default when the prompt does not repeat the Lens notes.
+It loads one current output with every open point and region on that cell.
+
+Use a plain scan for an explicitly semantic request or a text-only client:
 
 ```bash
 bash scripts/lens-context.sh --url http://localhost:2718 scan
 ```
 
-The entrypoint owns Lens availability detection. When `marimo-lens` is
-unavailable or the notebook has no live Lens object, it exits successfully
-with:
+The URL is the target. Do not run server discovery first.
+
+When the request needs the pixels captured at selection time, request the
+selection image instead:
+
+```bash
+# Pixels captured when the current selection was created
+bash scripts/lens-context.sh --url http://localhost:2718 \
+  scan --image selection
+```
+
+The entrypoint owns Lens availability detection. An unavailable package or a
+notebook with no live Lens object returns:
 
 ```json
 {"action":"scan","result":{"status":"absent"}}
 ```
 
-Continue with the ordinary Pair workflow and do not retry Lens during the same
-request. Scan again after the notebook state changes or the user explicitly
-asks.
+Continue with the ordinary Pair workflow and skip Lens calls for the rest of
+the request. Start a new scan for a later user request.
 
-A `ready` result contains bounded selection data:
+A ready scan contains bounded selection data:
 
 ```json
 {
@@ -34,8 +58,7 @@ A `ready` result contains bounded selection data:
     "status": "ready",
     "lensToken": "F3n...",
     "revision": 8,
-    "lens": {"variable": "lens"},
-    "selectionCount": 1,
+    "selectionCount": 2,
     "current": {
       "id": "243110...",
       "label": "S1",
@@ -47,24 +70,90 @@ A `ready` result contains bounded selection data:
       "status": "available",
       "defs": ["revenue"],
       "refs": ["orders"]
+    },
+    "image": {
+      "status": "available",
+      "source": "cell",
+      "path": "/tmp/marimo-pair-lens.A1b2c3/image.png",
+      "imageDir": "/tmp/marimo-pair-lens.A1b2c3",
+      "selectionCount": 2
     }
   }
 }
 ```
 
+The `image` field appears for `scan --image`. The command can return a ready
+scan with an image substatus such as `image-unavailable`,
+`revision-conflict`, or `capture-timeout`. Inspect the scan's semantic context
+and follow the image recovery rule for that substatus.
+
 Use `current` as the likely referent for "this", "here", or "the selected
-cell". The user's current request has priority over an older note. An explicit
-cell ID or variable in the request has priority over an inferred referent.
+cell". The explicit user request has priority over an older note. An explicit
+cell ID or variable has priority over an inferred referent.
 
-Keep the scan's stable selection ID, revision, and Lens token together. Later
-commands use them to avoid acting on selection state that changed during the
-task.
+Keep the scan's selection IDs, revision, and Lens token together. Later
+commands use them to prevent actions against changed human attention.
 
-## Load context progressively
+## Choose evidence before planning
 
-The selected output cell is the semantic notebook target. Read that cell
-through `marimo._code_mode`, then inspect ancestors or descendants only when
-the task needs them:
+Choose both evidence lanes before the first notebook mutation:
+
+| Request signal | Evidence |
+| --- | --- |
+| Cell identity, error, calculation, variable, upstream cause | Scan, selected cell code, bounded graph metadata |
+| Color, position, spacing, overlap, size, alignment, legibility, chart mark | Selection image |
+| Several relevant selections on one output | One current cell image containing every mark |
+| Compare the original view with current output | Selection image, plus a current cell image when `outdated` is true |
+| Verify a visual change | Fresh cell image after execution |
+| Text-only client | Scan, code, graph, DOM hint, and Lens text as needed |
+
+An image command materializes a private temporary file. Open the returned
+`path` with the client application's local-image reader before reasoning about
+pixels. An image command is incomplete until that read occurs.
+
+The JSON response contains image metadata and the path. It does not place PNG
+bytes in the model's text context. A text-only client skips image commands and
+must not claim pixel verification.
+
+After a plain scan, fetch one selection image with the stable scan identity:
+
+```bash
+bash scripts/lens-context.sh --url http://localhost:2718 \
+  image --selection-id '243110...' \
+  --revision 8 --lens-token 'F3n...'
+```
+
+Fetch the current full output for one cell:
+
+```bash
+bash scripts/lens-context.sh --url http://localhost:2718 \
+  image --cell BYtC --revision 8 --lens-token 'F3n...'
+```
+
+The cell image contains every open Lens point and region on that output. Its
+`selectionCount` reports how many marks were drawn. Use one cell image for
+several relevant selections that share the output.
+
+When those marks are legible, continue from that grouped image. Fetch a
+selection image when the original captured pixels are part of the request or
+one mark remains ambiguous.
+
+A selection image preserves the pixels captured when the user pointed. When
+its metadata reports `outdated: true`, use it as historical evidence and
+inspect a current cell image before editing or verifying current output.
+
+Track each returned `imageDir`. Remove it after the last image read:
+
+```bash
+bash scripts/lens-context.sh cleanup-images \
+  '/tmp/marimo-pair-lens.A1b2c3' \
+  '/tmp/marimo-pair-lens.D4e5f6'
+```
+
+## Resolve the semantic workset
+
+Read the selected output cell, required graph neighbors, and bounded runtime
+values in one scratchpad call:
 
 ```python
 import marimo._code_mode as cm
@@ -75,120 +164,145 @@ async with cm.get_context() as ctx:
     print(ctx.graph.ancestors("BYtC"))
 ```
 
-The scan, selected cell, note, DOM hint, and dataflow graph are the default
-context. Load standalone Lens text when those sources are insufficient:
+Form the workset from the explicit request and current selection. Add older
+selections when their note describes the same concrete change. Group the
+workset by `outputCellId` before loading code or images.
+
+Load standalone Lens text when a relevant note was truncated, when a secondary
+`notePreview` was truncated, or when the bounded scan omits detail needed for
+the request:
 
 ```bash
 bash scripts/lens-context.sh --url http://localhost:2718 \
   text --revision 8 --lens-token 'F3n...'
 ```
 
-Read the packet from `.result.text`. It can be substantially larger than the
-scan, so keep this step lazy.
+Read the packet from `.result.text`. It is larger than the scan, so keep this
+step tied to a specific missing detail.
 
-## Use images when pixels carry evidence
+Pair's cell edits and reruns preserve the scan identity. Rescan when:
 
-A selection image preserves the pixels and annotation captured when the user
-pointed:
+- The user starts a new request or changes human attention.
+- A command returns `revision-conflict`.
+- A command returns `selection-not-found`.
+- A command returns error code `lens_changed`.
+
+A Pair-triggered cell rerun is not a reason to rescan.
+
+## Show activity and apply one coherent mutation
+
+Start activity after grounding is complete and the edit plan is known. Choose
+a short activity label from the user's intent. The label is conversational
+display copy, while the message states the concrete action. Submit the
+activity command and one code-mode mutation call as one shell command joined
+by `&&`:
 
 ```bash
 bash scripts/lens-context.sh --url http://localhost:2718 \
-  image --selection-id '243110...' \
-  --revision 8 --lens-token 'F3n...'
+  activity --cell BYtC --lens-token 'F3n...' \
+  --label "Checking this now..." \
+  --message "Using completed orders in the selected output" &&
+bash scripts/execute-code.sh --url http://localhost:2718 <<'PY'
+import marimo._code_mode as cm
+
+async with cm.get_context() as ctx:
+    ctx.edit_cell(
+        "BYtC",
+        'revenue = orders.query("status == \'completed\'")\nrevenue',
+    )
+    ctx.run_cell("BYtC")
+PY
 ```
 
-Capture the current full output of a cell when visual verification depends on
-its latest rendering:
+Queue related `edit_cell`, `create_cell`, `delete_cell`, package, UI, and
+`run_cell` operations inside the same `cm.get_context()` block when they form
+one coherent change. Read every replaced cell body before submitting its full
+replacement.
+
+Activity remains visible through edits, execution, reactive descendants, and
+verification. Do not submit the mutation when the activity command fails.
+Vary the label naturally across runs. Suitable shapes include acknowledgments
+such as `On it...`, `Got it...`, and `Taking a look...`, investigations such
+as `Checking this now...` and `Tracing the mismatch...`, and concrete work
+such as `Fixing those bars...`, `Cleaning this up...`, and
+`Tuning the chart...`. Treat this vocabulary as inspiration and select by
+intent. Keep the chosen label stable through one activity. Avoid a mechanical
+label such as `Updating` when a clearer phrase fits. When a blocker requires
+user input after activity starts, update the same cell with a `Needs input`
+label and a concrete message. Leave its selections open.
+
+## Verify, resolve, and reveal
+
+Verification is a fresh scratchpad call after the mutation call completes.
+Inspect the target and every cell needed to support the final claim:
+
+```python
+import marimo._code_mode as cm
+
+async with cm.get_context() as ctx:
+    for cell_id in ("BYtC",):
+        cell = ctx.cells[cell_id]
+        print(cell_id, cell.status, cell.errors)
+```
+
+Every claimed cell must be `idle` with no relevant errors. Run a stale
+downstream cell explicitly when the notebook uses lazy execution. For visual
+work, fetch and open a fresh cell image after execution using the original
+scan identity:
 
 ```bash
 bash scripts/lens-context.sh --url http://localhost:2718 \
   image --cell BYtC --revision 8 --lens-token 'F3n...'
 ```
 
-The cell image contains every open Lens point and region on that output in one
-current raster. Prefer it when several relevant selections share a cell. Use a
-selection image when the pixels captured at the time of one selection are
-material to the request.
+This image read verifies current pixels. It does not replace the fresh runtime
+status and error check. Pair's own edit does not require another scan.
 
-Both commands return image metadata and a private temporary `path`. The cell
-result includes `selectionCount`, which reports how many marks were drawn.
-Read the file with the agent client's image tool. The JSON packet contains no
-image bytes. Remove the returned directory after the task:
-
-```bash
-bash scripts/lens-context.sh cleanup-images \
-  '/tmp/marimo-pair-lens.A1b2c3'
-```
-
-Use text and graph evidence for text-only models. An unavailable image does
-not invalidate its cell-backed selection.
-
-## Show progress in the notebook
-
-Mark the primary cell before focused work:
+After verification, resolve selections that share one change and rationale,
+then reveal the primary result in the same shell turn:
 
 ```bash
 bash scripts/lens-context.sh --url http://localhost:2718 \
-  activity --cell BYtC --lens-token 'F3n...' \
-  --label "On it" \
-  --message "Updating the aggregation used by this output"
-```
-
-Activity is transient and does not scroll. It stays visible while the cell
-rerenders and remains active until another activity or a reveal replaces it.
-Choose one short label for the run. The message names the concrete work.
-
-Keep activity visible while applying edits, running explicitly requested
-cells, waiting for reactive descendants, and correcting execution errors.
-After the mutation call completes, inspect the target and affected cells in a
-fresh execution call. A cell is complete when its status is `idle`. Run a
-relevant stale downstream cell explicitly when the notebook uses lazy
-execution.
-
-## Resolve and reveal completed attention
-
-Resolve a selection after the notebook edit is committed, affected cells have
-run, and the requested result is verified:
-
-```bash
-bash scripts/lens-context.sh --url http://localhost:2718 \
-  resolve '243110...' '8b20f4...' --revision 8 --lens-token 'F3n...' \
-  --summary "Updated the aggregation and verified the chart."
-```
-
-One resolve command commits every supplied selection together. Use one shared
-summary when one verified change addresses several annotations. Issue separate
-commands when the selections require distinct explanations.
-
-The summary is a concise receipt for the user. If the user requests changes,
-Lens can reopen a selection. A later scan exposes the prior receipt as
-`current.previousResolution`.
-
-Reveal the primary result after resolution:
-
-```bash
+  resolve '243110...' '8b20f4...' \
+  --revision 8 --lens-token 'F3n...' \
+  --summary "Updated the aggregation and verified the chart." &&
 bash scripts/lens-context.sh --url http://localhost:2718 \
   reveal --cell BYtC --lens-token 'F3n...' \
   --message "Updated the aggregation and verified the output"
 ```
 
-Reveal scrolls once, highlights the cell, and ends activity. Use one primary
-cell. Mention secondary cells in the normal response.
+One resolve command commits every supplied selection together. Use one shared
+summary when one verified result addresses them. Issue separate resolve
+commands for distinct changes or rationales.
 
-Leave the selection open when work is partial or verification fails. On
-`revision-conflict` or an error with code `lens_changed`, scan again and
-confirm that the current selection still grounds the completed work before
-retrying.
+Reveal scrolls to one primary cell, highlights it, and ends activity. Mention
+secondary cells in the normal response. Resolution is premature until the
+fresh runtime check passes. Remove every tracked image directory after the
+last image read, including when resolution or reveal fails:
 
-## Result handling
+```bash
+bash scripts/lens-context.sh cleanup-images \
+  '/tmp/marimo-pair-lens.A1b2c3' \
+  '/tmp/marimo-pair-lens.D4e5f6'
+```
+
+Pass all returned `imageDir` values to the same command.
+
+A reopened selection exposes the prior receipt as
+`current.previousResolution`. Treat the new user request as the current intent
+and use the receipt as history.
+
+## Handle results
 
 - `ready`: Continue from the returned Lens context.
-- `absent`: Continue with the ordinary Pair workflow.
-- `ambiguous`: Ask the user to leave one displayed Lens instance, then scan
-  again.
-- `selection-not-found`: Scan again because the selection changed or was
-  removed.
+- `absent`: Continue with the ordinary Pair workflow for this request.
+- `ambiguous`: Ask the user to leave one displayed Lens instance, then scan.
+- `selection-not-found`: Scan and confirm the new selection before acting.
 - `image-unavailable`: Continue from text and graph evidence.
 - `capture-timeout`: Continue from text or retry once after the output settles.
-- `revision-conflict` or error code `lens_changed`: Scan again before acting.
+- `revision-conflict`: Scan and confirm the workset before acting.
+- Error code `lens_changed`: Scan because the displayed Lens instance changed.
 - `error`: Report the returned code and keep unresolved attention open.
+
+Do not cross the two observation boundaries. Ground the request before the
+first mutation. Verify current runtime output before resolution.

--- a/skills/marimo-pair/scripts/execute-code.sh
+++ b/skills/marimo-pair/scripts/execute-code.sh
@@ -190,7 +190,8 @@ while IFS= read -r line && [[ "$done_received" == false ]]; do
           ;;
         done)
           if echo "$payload" | jq -e '.success == false' >/dev/null 2>&1; then
-            echo "$payload" | jq -r '.error.msg' >&2
+            echo "$payload" |
+              jq -r '.error.msg // .error.message // "Notebook execution failed."' >&2
             exit_code=1
           else
             echo "$payload" | jq -r '.output.data // empty'
@@ -206,5 +207,10 @@ done < <(curl -sN -X POST "${base}/api/kernel/execute" \
   ${auth_args[@]+"${auth_args[@]}"} \
   -d "$(jq -n --arg c "$code" '{code: $c}')" \
 )
+
+if [[ "$done_received" == false ]]; then
+  echo "Notebook execution ended before marimo reported completion." >&2
+  exit_code=1
+fi
 
 exit "$exit_code"

--- a/skills/marimo-pair/scripts/lens-context.py
+++ b/skills/marimo-pair/scripts/lens-context.py
@@ -1,0 +1,564 @@
+"""Execute one marimo Lens action in the active notebook kernel."""
+
+import base64 as _base64
+import json as _json
+import re as _re
+import secrets as _secrets
+import sys as _sys
+import types as _types
+import weakref as _weakref
+from collections.abc import Mapping as _Mapping
+
+_MAX_ALIASES = 4
+_MAX_AMBIGUOUS_LENSES = 8
+_MAX_CURRENT_NOTE = 1_000
+_MAX_DOM_TEXT = 240
+_MAX_GRAPH_NAME = 80
+_MAX_GRAPH_NAMES = 16
+_MAX_IDENTIFIER = 128
+_MAX_INDEXED_SELECTIONS = 16
+_MAX_NOTE_PREVIEW = 80
+_MAX_NOTEBOOK_PATH = 900
+_MAX_REASON = 240
+_TOKEN_MODULE = "_marimo_pair_lens_tokens"
+_MANGLED_BINDING = _re.compile(r"^_cell_(?:[^\W_][\w-]*?)(_.*)$")
+
+_CONFIG = _json.loads(_MARIMO_LENS_CONFIG_JSON)  # noqa: F821
+_ACTION = str(_CONFIG.get("action") or "")
+_ARGS = _CONFIG.get("args") if isinstance(_CONFIG.get("args"), _Mapping) else {}
+_MARKER = str(_CONFIG.get("marker") or "")
+
+
+def _bounded(_value, _maximum):
+    _text = str(_value or "")
+    return _text[:_maximum], len(_text) > _maximum
+
+
+def _identifier(_value):
+    return _bounded(_value, _MAX_IDENTIFIER)[0]
+
+
+def _binding_name(_value):
+    _name = str(_value)
+    _match = _MANGLED_BINDING.match(_name)
+    return _name if _match is None else _match.group(1)
+
+
+def _ordered_names(_values):
+    return sorted(set(_values), key=lambda _name: (_name.startswith("_"), _name))
+
+
+def _find_lenses(_globals, _lens_type):
+    _by_widget = {}
+    for _name, _value in _globals.items():
+        if isinstance(_value, _lens_type):
+            _widget = _value
+        elif type(_value).__module__.startswith("marimo."):
+            _widget = getattr(_value, "widget", None)
+        else:
+            continue
+        if not isinstance(_widget, _lens_type):
+            continue
+        if hasattr(_widget, "comm") and _widget.comm is None:
+            continue
+        _entry = _by_widget.setdefault(id(_widget), {"widget": _widget, "names": set()})
+        _entry["names"].add(_binding_name(_name))
+    return list(_by_widget.values())
+
+
+def _token_registry():
+    _module = _sys.modules.get(_TOKEN_MODULE)
+    if _module is None:
+        _module = _types.ModuleType(_TOKEN_MODULE)
+        _module.entries = {}
+        _sys.modules[_TOKEN_MODULE] = _module
+    _entries = _module.entries
+    for _token, _reference in list(_entries.items()):
+        if _reference() is None:
+            _entries.pop(_token, None)
+    return _entries
+
+
+def _lens_token(_widget):
+    _entries = _token_registry()
+    for _token, _reference in _entries.items():
+        if _reference() is _widget:
+            return _token
+    _token = _secrets.token_urlsafe(24)
+    _entries[_token] = _weakref.ref(
+        _widget,
+        lambda _reference, _token=_token: _entries.pop(_token, None),
+    )
+    return _token
+
+
+def _preview(_value, _maximum=_MAX_NOTE_PREVIEW):
+    _text, _truncated = _bounded(_value, _maximum)
+    return {"text": _text, "truncated": _truncated}
+
+
+def _selection_index(_selection, _current_id):
+    _anchor = _selection.get("anchor")
+    _snapshot = _selection.get("snapshot")
+    return {
+        "id": _identifier(_selection.get("id")),
+        "label": _identifier(_selection.get("label")),
+        "current": _selection.get("id") == _current_id,
+        "outputCellId": _identifier(_selection.get("outputCellId")),
+        "cellStatus": _identifier(_selection.get("cellStatus")),
+        "anchorKind": _anchor.get("kind") if isinstance(_anchor, _Mapping) else None,
+        "notePreview": _preview(_selection.get("note")),
+        "snapshotStatus": (
+            _snapshot.get("status") if isinstance(_snapshot, _Mapping) else None
+        ),
+    }
+
+
+def _current_selection(_selection):
+    if not isinstance(_selection, _Mapping):
+        return None
+    _snapshot = _selection.get("snapshot")
+    _result = {
+        "id": _identifier(_selection.get("id")),
+        "label": _identifier(_selection.get("label")),
+        "outputCellId": _identifier(_selection.get("outputCellId")),
+        "cellStatus": _identifier(_selection.get("cellStatus")),
+        "anchor": _selection.get("anchor"),
+        "note": _preview(_selection.get("note"), _MAX_CURRENT_NOTE),
+        "snapshotStatus": (
+            _snapshot.get("status") if isinstance(_snapshot, _Mapping) else None
+        ),
+    }
+    _dom_hint = _selection.get("domHint")
+    if isinstance(_dom_hint, _Mapping):
+        _dom = {}
+        _truncated = False
+        for _field, _maximum in (
+            ("tag", 40),
+            ("role", 80),
+            ("ariaLabel", 160),
+            ("title", 160),
+            ("text", _MAX_DOM_TEXT),
+        ):
+            _text, _field_truncated = _bounded(_dom_hint.get(_field), _maximum)
+            if _text:
+                _dom[_field] = _text
+            _truncated = _truncated or _field_truncated
+        if _dom:
+            _result["domHint"] = _dom
+        if _truncated:
+            _result["domHintTruncated"] = True
+    _previous = _selection.get("previousResolution")
+    if isinstance(_previous, _Mapping):
+        _addressed_at, _ = _bounded(_previous.get("addressedAt"), 80)
+        if _addressed_at:
+            _receipt = {"addressedAt": _addressed_at}
+            _summary, _ = _bounded(_previous.get("summary"), 240)
+            if _summary:
+                _receipt["summary"] = _summary
+            _result["previousResolution"] = _receipt
+    return _result
+
+
+def _graph_names(_values):
+    _all = sorted(str(_value) for _value in _values)
+    _included = [
+        _bounded(_value, _MAX_GRAPH_NAME)[0] for _value in _all[:_MAX_GRAPH_NAMES]
+    ]
+    return _included, max(0, len(_all) - len(_included))
+
+
+def _cell_summary(_ctx, _cell_id):
+    if not isinstance(_cell_id, str):
+        return None
+    _cell = _ctx.graph.cells.get(_cell_id)
+    if _cell is None:
+        return {"id": _identifier(_cell_id), "status": "missing"}
+    _defs, _omitted_defs = _graph_names(_cell.defs)
+    _refs, _omitted_refs = _graph_names(_cell.refs)
+    _result = {
+        "id": _identifier(_cell_id),
+        "status": "available",
+        "defs": _defs,
+        "refs": _refs,
+        "codeCharacters": len(str(_cell.code or "")),
+    }
+    if _omitted_defs:
+        _result["omittedDefCount"] = _omitted_defs
+    if _omitted_refs:
+        _result["omittedRefCount"] = _omitted_refs
+    return _result
+
+
+def _notebook_summary(_value):
+    if not isinstance(_value, _Mapping):
+        return None
+    _path, _path_truncated = _bounded(_value.get("path"), _MAX_NOTEBOOK_PATH)
+    _result = {"path": _path, "available": _value.get("available") is True}
+    if _path_truncated:
+        _result["pathTruncated"] = True
+    if _value.get("available") is False:
+        _reason, _reason_truncated = _bounded(_value.get("reason"), _MAX_REASON)
+        _result["reason"] = _reason
+        if _reason_truncated:
+            _result["reasonTruncated"] = True
+    return _result
+
+
+def _selection_rows(_references):
+    _values = _references.get("selections")
+    if not isinstance(_values, list):
+        return []
+    return [dict(_value) for _value in _values if isinstance(_value, _Mapping)]
+
+
+def _scan(_ctx, _candidate, _context, _token):
+    _references = _context.references
+    _selections = _selection_rows(_references)
+    _current_id = _references.get("currentSelectionId")
+    _current = next(
+        (
+            _selection
+            for _selection in _selections
+            if _selection.get("id") == _current_id
+        ),
+        None,
+    )
+    _ordered = ([] if _current is None else [_current]) + [
+        _selection for _selection in _selections if _selection.get("id") != _current_id
+    ]
+    _indexed = _ordered[:_MAX_INDEXED_SELECTIONS]
+    _names = _ordered_names(_candidate["names"])
+    return {
+        "status": "ready",
+        "lensToken": _token,
+        "revision": _context.revision,
+        "lens": {
+            "variable": _identifier(_names[0]),
+            "aliases": [_identifier(_name) for _name in _names[1 : _MAX_ALIASES + 1]],
+            "omittedAliasCount": max(0, len(_names) - _MAX_ALIASES - 1),
+        },
+        "notebook": _notebook_summary(_references.get("notebook")),
+        "selectionCount": len(_selections),
+        "omittedSelectionCount": max(0, len(_selections) - len(_indexed)),
+        "current": _current_selection(_current),
+        "selections": [
+            _selection_index(_selection, _current_id) for _selection in _indexed
+        ],
+        "currentCell": _cell_summary(
+            _ctx,
+            None if _current is None else _current.get("outputCellId"),
+        ),
+    }
+
+
+def _revision_conflict(_context, _expected_revision):
+    if _context.revision == _expected_revision:
+        return None
+    return {
+        "status": "revision-conflict",
+        "expectedRevision": _expected_revision,
+        "revision": _context.revision,
+    }
+
+
+def _find_selection(_context, _selection_id):
+    _selection = next(
+        (
+            _candidate
+            for _candidate in _selection_rows(_context.references)
+            if _candidate.get("id") == _selection_id
+        ),
+        None,
+    )
+    if _selection is None:
+        return None, {
+            "status": "selection-not-found",
+            "selectionId": _identifier(_selection_id),
+            "revision": _context.revision,
+        }
+    return _selection, None
+
+
+def _find_selections(_context, _selection_ids):
+    if not isinstance(_selection_ids, list) or not _selection_ids:
+        return None, {
+            "status": "error",
+            "code": "invalid_selection",
+            "error": "Pair must supply at least one selection ID.",
+        }
+    if (
+        len(_selection_ids) > 64
+        or any(not isinstance(_selection_id, str) for _selection_id in _selection_ids)
+        or len(_selection_ids) != len(set(_selection_ids))
+    ):
+        return None, {
+            "status": "error",
+            "code": "invalid_selection",
+            "error": "Pair must supply 1 through 64 unique selection IDs.",
+        }
+    _selections = []
+    for _selection_id in _selection_ids:
+        _selection, _error = _find_selection(_context, _selection_id)
+        if _error is not None:
+            return None, _error
+        _selections.append(_selection)
+    return _selections, None
+
+
+def _selection_image(_context, _args):
+    _conflict = _revision_conflict(_context, _args.get("revision"))
+    if _conflict is not None:
+        return _conflict
+    _selection, _error = _find_selection(_context, _args.get("selectionId"))
+    if _error is not None:
+        return _error
+    _image = next(
+        (
+            _candidate
+            for _candidate in _context.images
+            if _candidate.selection_id == _selection.get("id")
+        ),
+        None,
+    )
+    if _image is None:
+        return {
+            "status": "image-unavailable",
+            "selection": _identifier(_selection.get("label")),
+            "selectionId": _identifier(_selection.get("id")),
+            "revision": _context.revision,
+        }
+    return {
+        "status": "ready",
+        "source": "selection",
+        "selection": _identifier(_selection.get("label")),
+        "selectionId": _identifier(_selection.get("id")),
+        "revision": _context.revision,
+        "cellId": _identifier(_selection.get("outputCellId")),
+        "mediaType": _image.media_type,
+        "bytes": len(_image.data),
+        "width": _image.width,
+        "height": _image.height,
+        "sha256": _image.sha256,
+        "capturedAt": _image.captured_at,
+        "outdated": _image.outdated,
+        "data": _base64.b64encode(_image.data).decode("ascii"),
+    }
+
+
+def _read_output_capture(_widget, _request_id):
+    _capture = _widget._read_output_capture(_request_id)
+    _result = {
+        "status": str(_capture.status),
+        "requestId": str(_capture.request_id),
+        "cellId": str(_capture.cell_id),
+        "selectionCount": len(_capture.selection_ids),
+    }
+    if _capture.status == "pending":
+        return _result
+    if _capture.status == "failed":
+        return {
+            **_result,
+            "errorCode": _identifier(_capture.error_code or "capture_failed"),
+            "error": _bounded(_capture.error or "Cell output capture failed.", 500)[0],
+        }
+    _image = _capture.image
+    if (
+        _capture.status != "available"
+        or _image is None
+        or getattr(_image, "request_id", None) != _capture.request_id
+        or getattr(_image, "cell_id", None) != _capture.cell_id
+    ):
+        return {
+            **_result,
+            "status": "error",
+            "code": "invalid_capture",
+            "error": "Lens returned an invalid output capture result.",
+        }
+    return {
+        **_result,
+        "source": "cell",
+        "mediaType": _image.media_type,
+        "bytes": len(_image.data),
+        "width": _image.width,
+        "height": _image.height,
+        "sha256": _image.sha256,
+        "capturedAt": _image.captured_at,
+        "data": _base64.b64encode(_image.data).decode("ascii"),
+    }
+
+
+def _dispatch(_ctx, _widget, _candidate, _token):
+    if _ACTION == "activity":
+        _widget.activity(
+            _ARGS.get("cellId"),
+            label=_ARGS.get("label"),
+            message=_ARGS.get("message"),
+        )
+        return {"status": "activity-requested", "cellId": _ARGS.get("cellId")}
+    if _ACTION == "reveal":
+        _widget.reveal(_ARGS.get("cellId"), message=_ARGS.get("message"))
+        return {"status": "reveal-requested", "cellId": _ARGS.get("cellId")}
+    if _ACTION == "output.capture.read":
+        return _read_output_capture(_widget, _ARGS.get("requestId"))
+
+    _context = _widget.context()
+    if _ACTION == "output.capture.start":
+        _conflict = _revision_conflict(_context, _ARGS.get("revision"))
+        if _conflict is not None:
+            return _conflict
+        _request_id = _widget._start_output_capture(_ARGS.get("cellId"))
+        return {
+            "status": "pending",
+            "requestId": _request_id,
+            "cellId": _ARGS.get("cellId"),
+        }
+    if _ACTION == "scan":
+        return _scan(_ctx, _candidate, _context, _token)
+    if _ACTION == "text":
+        _conflict = _revision_conflict(_context, _ARGS.get("revision"))
+        if _conflict is not None:
+            return _conflict
+        return {
+            "status": "ready",
+            "revision": _context.revision,
+            "text": _context.text,
+        }
+    if _ACTION == "selection.image":
+        return _selection_image(_context, _ARGS)
+    if _ACTION == "resolve":
+        _conflict = _revision_conflict(_context, _ARGS.get("revision"))
+        if _conflict is not None:
+            return _conflict
+        _selections, _error = _find_selections(
+            _context,
+            _ARGS.get("selectionIds"),
+        )
+        if _error is not None:
+            return _error
+        _revision = _widget.resolve(
+            [_selection["id"] for _selection in _selections],
+            expected_revision=_context.revision,
+            summary=_ARGS.get("summary"),
+        )
+        return {
+            "status": "resolved",
+            "selectionCount": len(_selections),
+            "revision": _revision,
+        }
+    return {
+        "status": "error",
+        "code": "invalid_action",
+        "error": "Pair requested an unknown Lens action.",
+    }
+
+
+def _identity_error(_token):
+    if _ACTION not in {
+        "text",
+        "selection.image",
+        "output.capture.start",
+        "output.capture.read",
+        "activity",
+        "reveal",
+        "resolve",
+    }:
+        return None
+    _expected = _ARGS.get("lensToken")
+    if not isinstance(_expected, str) or not _expected:
+        return {
+            "status": "error",
+            "code": "lens_token_required",
+            "error": "Pair must supply the Lens identity from its grounding scan.",
+        }
+    if _expected != _token:
+        return {
+            "status": "error",
+            "code": "lens_changed",
+            "error": "The Lens instance changed after the grounding scan.",
+        }
+    return None
+
+
+def _lens_error(_error):
+    _code = _identifier(getattr(_error, "code", None) or "lens_error")
+    if _code == "selection_not_found":
+        _selection_ids = _ARGS.get("selectionIds")
+        _selection_id = (
+            _selection_ids[0]
+            if isinstance(_selection_ids, list) and _selection_ids
+            else _ARGS.get("selectionId")
+        )
+        return {
+            "status": "selection-not-found",
+            "selectionId": _identifier(_selection_id),
+            "revision": getattr(_error, "revision", None),
+        }
+    if _code == "revision_conflict":
+        return {
+            "status": "revision-conflict",
+            "expectedRevision": _ARGS.get("revision"),
+            "revision": getattr(_error, "revision", None),
+        }
+    return {
+        "status": "error",
+        "code": _code,
+        "revision": getattr(_error, "revision", None),
+        "error": _bounded(_error, 500)[0],
+    }
+
+
+async def _run():
+    try:
+        import marimo._code_mode as _cm
+        from marimo_lens import Lens as _Lens
+        from marimo_lens import LensError as _LensError
+    except ModuleNotFoundError as _error:
+        if _error.name == "marimo_lens":
+            return {"status": "absent"}
+        return {
+            "status": "error",
+            "code": "runtime_unavailable",
+            "error": _bounded(f"{type(_error).__name__}: {_error}", 500)[0],
+        }
+
+    async with _cm.get_context() as _ctx:
+        _candidates = _find_lenses(_ctx.globals, _Lens)
+        if not _candidates:
+            return {"status": "absent"}
+        if len(_candidates) > 1:
+            return {
+                "status": "ambiguous",
+                "lenses": [
+                    _ordered_names(_candidate["names"])
+                    for _candidate in _candidates[:_MAX_AMBIGUOUS_LENSES]
+                ],
+                "omittedLensCount": max(0, len(_candidates) - _MAX_AMBIGUOUS_LENSES),
+            }
+        _candidate = _candidates[0]
+        _widget = _candidate["widget"]
+        _token = _lens_token(_widget)
+        _error = _identity_error(_token)
+        if _error is not None:
+            return _error
+        try:
+            return _dispatch(_ctx, _widget, _candidate, _token)
+        except _LensError as _error:
+            return _lens_error(_error)
+        except Exception as _error:
+            return {
+                "status": "error",
+                "code": "lens_error",
+                "error": _bounded(f"{type(_error).__name__}: {_error}", 500)[0],
+            }
+
+
+_RESULT = await _run()  # noqa: F704
+print(
+    _MARKER
+    + _json.dumps(
+        {"action": _ACTION, "result": _RESULT},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+)

--- a/skills/marimo-pair/scripts/lens-context.sh
+++ b/skills/marimo-pair/scripts/lens-context.sh
@@ -1,0 +1,395 @@
+#!/usr/bin/env bash
+# Read and act on marimo Lens state through execute-code.sh.
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  lens-context.sh [TARGET] scan
+  lens-context.sh [TARGET] text --revision N --lens-token TOKEN
+  lens-context.sh [TARGET] image --selection-id ID --revision N --lens-token TOKEN
+  lens-context.sh [TARGET] image --cell CELL --revision N --lens-token TOKEN
+  lens-context.sh [TARGET] activity --cell CELL --lens-token TOKEN [--label TEXT] [--message TEXT]
+  lens-context.sh [TARGET] reveal --cell CELL --lens-token TOKEN [--message TEXT]
+  lens-context.sh [TARGET] resolve ID... --revision N --lens-token TOKEN [--summary TEXT]
+  lens-context.sh cleanup-images IMAGE_DIR
+
+TARGET accepts --url URL, --port PORT, --session ID, and --token TOKEN.
+EOF
+  exit 2
+}
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+execute_script="${script_dir}/execute-code.sh"
+python_script="${script_dir}/lens-context.py"
+target_args=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --url | --port | --session | --token)
+      [[ $# -ge 2 ]] || usage
+      target_args+=("$1" "$2")
+      shift 2
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+command="${1:-}"
+[[ -n "$command" ]] || usage
+shift
+
+revision=""
+lens_token=""
+selection_id=""
+cell_id=""
+message=""
+message_set=false
+label=""
+label_set=false
+summary=""
+summary_set=false
+positionals=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --revision)
+      [[ $# -ge 2 && -z "$revision" ]] || usage
+      revision="$2"
+      shift 2
+      ;;
+    --lens-token)
+      [[ $# -ge 2 && -z "$lens_token" ]] || usage
+      lens_token="$2"
+      shift 2
+      ;;
+    --selection-id)
+      [[ $# -ge 2 && -z "$selection_id" ]] || usage
+      selection_id="$2"
+      shift 2
+      ;;
+    --cell)
+      [[ $# -ge 2 && -z "$cell_id" ]] || usage
+      cell_id="$2"
+      shift 2
+      ;;
+    --message)
+      [[ $# -ge 2 && "$message_set" == false ]] || usage
+      message="$2"
+      message_set=true
+      shift 2
+      ;;
+    --label)
+      [[ $# -ge 2 && "$label_set" == false ]] || usage
+      label="$2"
+      label_set=true
+      shift 2
+      ;;
+    --summary)
+      [[ $# -ge 2 && "$summary_set" == false ]] || usage
+      summary="$2"
+      summary_set=true
+      shift 2
+      ;;
+    -*)
+      usage
+      ;;
+    *)
+      positionals+=("$1")
+      shift
+      ;;
+  esac
+done
+
+case "$command" in
+  scan)
+    [[ ${#positionals[@]} -eq 0 && -z "$revision$lens_token$selection_id$cell_id" ]] ||
+      usage
+    [[ "$message_set" == false && "$label_set" == false && "$summary_set" == false ]] ||
+      usage
+    action="scan"
+    args_json="{}"
+    ;;
+  text)
+    [[ ${#positionals[@]} -eq 0 && "$revision" =~ ^[0-9]+$ ]] || usage
+    [[ -n "$lens_token" && -z "$selection_id$cell_id" ]] || usage
+    [[ "$message_set" == false && "$label_set" == false && "$summary_set" == false ]] ||
+      usage
+    action="text"
+    args_json=$(jq -cn \
+      --argjson revision "$revision" \
+      --arg lensToken "$lens_token" \
+      '{revision: $revision, lensToken: $lensToken}')
+    ;;
+  image)
+    [[ ${#positionals[@]} -eq 0 && -n "$lens_token" ]] || usage
+    [[ "$message_set" == false && "$label_set" == false && "$summary_set" == false ]] ||
+      usage
+    if [[ -n "$selection_id" && -z "$cell_id" && "$revision" =~ ^[0-9]+$ ]]; then
+      action="selection.image"
+      args_json=$(jq -cn \
+        --arg selectionId "$selection_id" \
+        --argjson revision "$revision" \
+        --arg lensToken "$lens_token" \
+        '{selectionId: $selectionId, revision: $revision, lensToken: $lensToken}')
+    elif [[ -n "$cell_id" && -z "$selection_id" && "$revision" =~ ^[0-9]+$ ]]; then
+      action="output.capture.start"
+      args_json=$(jq -cn \
+        --arg cellId "$cell_id" \
+        --argjson revision "$revision" \
+        --arg lensToken "$lens_token" \
+        '{cellId: $cellId, revision: $revision, lensToken: $lensToken}')
+    else
+      usage
+    fi
+    ;;
+  activity | reveal)
+    [[ ${#positionals[@]} -eq 0 && -n "$cell_id" && -n "$lens_token" ]] || usage
+    [[ -z "$revision$selection_id" && "$summary_set" == false ]] || usage
+    [[ "$command" == "activity" || "$label_set" == false ]] || usage
+    message_json="null"
+    [[ "$message_set" == false ]] ||
+      message_json=$(jq -Rn --arg value "$message" '$value')
+    label_json="null"
+    [[ "$label_set" == false ]] ||
+      label_json=$(jq -Rn --arg value "$label" '$value')
+    action="$command"
+    args_json=$(jq -cn \
+      --arg cellId "$cell_id" \
+      --arg lensToken "$lens_token" \
+      --argjson label "$label_json" \
+      --argjson message "$message_json" \
+      '{
+        cellId: $cellId,
+        lensToken: $lensToken,
+        label: $label,
+        message: $message
+      }')
+    ;;
+  resolve)
+    [[ ${#positionals[@]} -ge 1 && "$revision" =~ ^[0-9]+$ ]] || usage
+    [[ -n "$lens_token" && -z "$selection_id$cell_id" ]] || usage
+    [[ "$message_set" == false && "$label_set" == false ]] || usage
+    selection_ids_json=$(jq -cn '$ARGS.positional' --args "${positionals[@]}")
+    summary_json="null"
+    [[ "$summary_set" == false ]] ||
+      summary_json=$(jq -Rn --arg value "$summary" '$value')
+    action="resolve"
+    args_json=$(jq -cn \
+      --argjson selectionIds "$selection_ids_json" \
+      --argjson revision "$revision" \
+      --arg lensToken "$lens_token" \
+      --argjson summary "$summary_json" \
+      '{
+        selectionIds: $selectionIds,
+        revision: $revision,
+        lensToken: $lensToken,
+        summary: $summary
+      }')
+    ;;
+  cleanup-images)
+    [[ ${#target_args[@]} -eq 0 && ${#positionals[@]} -eq 1 ]] || usage
+    [[ -z "$revision$lens_token$selection_id$cell_id" ]] || usage
+    [[ "$message_set" == false && "$label_set" == false && "$summary_set" == false ]] ||
+      usage
+    image_dir="${positionals[0]}"
+    ;;
+  *)
+    usage
+    ;;
+esac
+
+invoke_action() {
+  local requested_action="$1"
+  local requested_args="$2"
+  local marker config config_literal output line payload=""
+
+  marker="__MARIMO_PAIR_LENS_${RANDOM}_${RANDOM}_$$_"
+  config=$(jq -cn \
+    --arg action "$requested_action" \
+    --argjson args "$requested_args" \
+    --arg marker "$marker" \
+    '{action: $action, args: $args, marker: $marker}')
+  config_literal=$(jq -Rn --arg value "$config" '$value')
+  output=$(
+    {
+      printf '_MARIMO_LENS_CONFIG_JSON = %s\n' "$config_literal"
+      cat "$python_script"
+    } | bash "$execute_script" ${target_args[@]+"${target_args[@]}"}
+  )
+
+  while IFS= read -r line; do
+    case "$line" in
+      "$marker"*) payload="${line#"$marker"}" ;;
+    esac
+  done <<<"$output"
+
+  if [[ -z "$payload" ]] || ! jq -e \
+    --arg action "$requested_action" \
+    '.action == $action and (.result | type == "object")' \
+    >/dev/null <<<"$payload"; then
+    echo "Lens returned an invalid response." >&2
+    return 1
+  fi
+  printf '%s\n' "$payload"
+}
+
+status_exit() {
+  local response="$1"
+  case "$(jq -r '.result.status // empty' <<<"$response")" in
+    absent | activity-requested | available | ready | removed | resolved | reveal-requested)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+emit_response() {
+  local response="$1"
+  local public_action="$2"
+  jq -c --arg action "$public_action" '.action = $action' <<<"$response"
+  status_exit "$response"
+}
+
+cleanup_image_dir() {
+  local requested_dir="$1"
+  local tmp_root canonical_dir
+  tmp_root=$(cd "${TMPDIR:-/tmp}" && pwd -P)
+  [[ -d "$requested_dir" && ! -L "$requested_dir" ]] || return 1
+  canonical_dir=$(cd "$requested_dir" && pwd -P)
+  [[ "$(dirname "$canonical_dir")" == "$tmp_root" ]] || return 1
+  [[ "$(basename "$canonical_dir")" == marimo-pair-lens.* ]] || return 1
+  [[ -f "$canonical_dir/.marimo-pair-lens-images" ]] || return 1
+  rm -rf -- "$canonical_dir"
+  jq -cn \
+    --arg imageDir "$canonical_dir" \
+    '{action: "cleanup-images", result: {status: "removed", imageDir: $imageDir}}'
+}
+
+materialize_image() {
+  local response="$1"
+  local status tmp_root image_dir image_path
+  local expected_bytes actual_bytes expected_sha actual_sha
+  status=$(jq -r '.result.status // empty' <<<"$response")
+  [[ "$status" == "ready" || "$status" == "available" ]] || {
+    emit_response "$response" "image"
+    return
+  }
+  jq -e '
+    .result.mediaType == "image/png"
+    and (.result.data | type == "string")
+    and (.result.bytes | type == "number")
+    and (.result.sha256 | type == "string")
+  ' >/dev/null <<<"$response" || {
+    echo "Lens returned invalid image metadata." >&2
+    return 1
+  }
+
+  tmp_root=$(cd "${TMPDIR:-/tmp}" && pwd -P)
+  image_dir=$(mktemp -d "${tmp_root}/marimo-pair-lens.XXXXXX")
+  chmod 700 "$image_dir"
+  : >"$image_dir/.marimo-pair-lens-images"
+  image_path="$image_dir/image.png"
+  if base64 --help 2>&1 | grep -q -- '--decode'; then
+    jq -r '.result.data' <<<"$response" | base64 --decode >"$image_path"
+  else
+    jq -r '.result.data' <<<"$response" | base64 -D >"$image_path"
+  fi
+  chmod 600 "$image_path"
+
+  expected_bytes=$(jq -r '.result.bytes' <<<"$response")
+  actual_bytes=$(wc -c <"$image_path" | tr -d ' ')
+  expected_sha=$(jq -r '.result.sha256' <<<"$response")
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual_sha=$(sha256sum "$image_path" | awk '{print $1}')
+  else
+    actual_sha=$(shasum -a 256 "$image_path" | awk '{print $1}')
+  fi
+  if [[ "$actual_bytes" != "$expected_bytes" || "$actual_sha" != "$expected_sha" ]]; then
+    rm -rf -- "$image_dir"
+    echo "Decoded image does not match Lens metadata." >&2
+    return 1
+  fi
+
+  jq -c \
+    --arg path "$image_path" \
+    --arg imageDir "$image_dir" \
+    '
+      .action = "image"
+      | .result |= (
+          del(.data)
+          + {path: $path, imageDir: $imageDir, temporary: true}
+        )
+    ' <<<"$response"
+}
+
+if [[ "$command" == "cleanup-images" ]]; then
+  cleanup_image_dir "$image_dir" || {
+    echo "Refusing to remove an image directory not created by marimo-pair." >&2
+    exit 1
+  }
+  exit
+fi
+
+if [[ "$command" != "image" ]]; then
+  response=$(invoke_action "$action" "$args_json")
+  emit_response "$response" "$command"
+  exit
+fi
+
+response=$(invoke_action "$action" "$args_json")
+if [[ "$action" == "selection.image" ]]; then
+  materialize_image "$response"
+  exit
+fi
+
+status=$(jq -r '.result.status // empty' <<<"$response")
+if [[ "$status" != "pending" ]]; then
+  emit_response "$response" "image"
+  exit
+fi
+request_id=$(jq -r '.result.requestId // empty' <<<"$response")
+[[ -n "$request_id" ]] || {
+  echo "Lens did not return a capture request ID." >&2
+  exit 1
+}
+read_args=$(jq -cn \
+  --arg requestId "$request_id" \
+  --arg lensToken "$lens_token" \
+  '{requestId: $requestId, lensToken: $lensToken}')
+deadline=$((SECONDS + 20))
+
+while ((SECONDS < deadline)); do
+  response=$(invoke_action "output.capture.read" "$read_args")
+  status=$(jq -r '.result.status // empty' <<<"$response")
+  case "$status" in
+    pending)
+      sleep 0.25
+      ;;
+    available)
+      materialize_image "$response"
+      exit
+      ;;
+    *)
+      emit_response "$response" "image"
+      exit
+      ;;
+  esac
+done
+
+jq -cn \
+  --arg requestId "$request_id" \
+  --arg cellId "$cell_id" \
+  '{
+    action: "image",
+    result: {
+      status: "capture-timeout",
+      requestId: $requestId,
+      cellId: $cellId
+    }
+  }'
+exit 1

--- a/skills/marimo-pair/scripts/lens-context.sh
+++ b/skills/marimo-pair/scripts/lens-context.sh
@@ -5,14 +5,14 @@ set -euo pipefail
 usage() {
   cat >&2 <<'EOF'
 Usage:
-  lens-context.sh [TARGET] scan
+  lens-context.sh [TARGET] scan [--image selection|cell]
   lens-context.sh [TARGET] text --revision N --lens-token TOKEN
   lens-context.sh [TARGET] image --selection-id ID --revision N --lens-token TOKEN
   lens-context.sh [TARGET] image --cell CELL --revision N --lens-token TOKEN
   lens-context.sh [TARGET] activity --cell CELL --lens-token TOKEN [--label TEXT] [--message TEXT]
   lens-context.sh [TARGET] reveal --cell CELL --lens-token TOKEN [--message TEXT]
   lens-context.sh [TARGET] resolve ID... --revision N --lens-token TOKEN [--summary TEXT]
-  lens-context.sh cleanup-images IMAGE_DIR
+  lens-context.sh cleanup-images IMAGE_DIR...
 
 TARGET accepts --url URL, --port PORT, --session ID, and --token TOKEN.
 EOF
@@ -51,6 +51,7 @@ label=""
 label_set=false
 summary=""
 summary_set=false
+scan_image=""
 positionals=()
 
 while [[ $# -gt 0 ]]; do
@@ -93,6 +94,11 @@ while [[ $# -gt 0 ]]; do
       summary_set=true
       shift 2
       ;;
+    --image)
+      [[ $# -ge 2 && -z "$scan_image" ]] || usage
+      scan_image="$2"
+      shift 2
+      ;;
     -*)
       usage
       ;;
@@ -109,10 +115,13 @@ case "$command" in
       usage
     [[ "$message_set" == false && "$label_set" == false && "$summary_set" == false ]] ||
       usage
+    [[ -z "$scan_image" || "$scan_image" == "selection" || "$scan_image" == "cell" ]] ||
+      usage
     action="scan"
     args_json="{}"
     ;;
   text)
+    [[ -z "$scan_image" ]] || usage
     [[ ${#positionals[@]} -eq 0 && "$revision" =~ ^[0-9]+$ ]] || usage
     [[ -n "$lens_token" && -z "$selection_id$cell_id" ]] || usage
     [[ "$message_set" == false && "$label_set" == false && "$summary_set" == false ]] ||
@@ -124,6 +133,7 @@ case "$command" in
       '{revision: $revision, lensToken: $lensToken}')
     ;;
   image)
+    [[ -z "$scan_image" ]] || usage
     [[ ${#positionals[@]} -eq 0 && -n "$lens_token" ]] || usage
     [[ "$message_set" == false && "$label_set" == false && "$summary_set" == false ]] ||
       usage
@@ -146,6 +156,7 @@ case "$command" in
     fi
     ;;
   activity | reveal)
+    [[ -z "$scan_image" ]] || usage
     [[ ${#positionals[@]} -eq 0 && -n "$cell_id" && -n "$lens_token" ]] || usage
     [[ -z "$revision$selection_id" && "$summary_set" == false ]] || usage
     [[ "$command" == "activity" || "$label_set" == false ]] || usage
@@ -169,6 +180,7 @@ case "$command" in
       }')
     ;;
   resolve)
+    [[ -z "$scan_image" ]] || usage
     [[ ${#positionals[@]} -ge 1 && "$revision" =~ ^[0-9]+$ ]] || usage
     [[ -n "$lens_token" && -z "$selection_id$cell_id" ]] || usage
     [[ "$message_set" == false && "$label_set" == false ]] || usage
@@ -190,11 +202,11 @@ case "$command" in
       }')
     ;;
   cleanup-images)
-    [[ ${#target_args[@]} -eq 0 && ${#positionals[@]} -eq 1 ]] || usage
+    [[ -z "$scan_image" ]] || usage
+    [[ ${#target_args[@]} -eq 0 && ${#positionals[@]} -ge 1 ]] || usage
     [[ -z "$revision$lens_token$selection_id$cell_id" ]] || usage
     [[ "$message_set" == false && "$label_set" == false && "$summary_set" == false ]] ||
       usage
-    image_dir="${positionals[0]}"
     ;;
   *)
     usage
@@ -255,7 +267,7 @@ emit_response() {
   status_exit "$response"
 }
 
-cleanup_image_dir() {
+canonical_image_dir() {
   local requested_dir="$1"
   local tmp_root canonical_dir
   tmp_root=$(cd "${TMPDIR:-/tmp}" && pwd -P)
@@ -264,10 +276,31 @@ cleanup_image_dir() {
   [[ "$(dirname "$canonical_dir")" == "$tmp_root" ]] || return 1
   [[ "$(basename "$canonical_dir")" == marimo-pair-lens.* ]] || return 1
   [[ -f "$canonical_dir/.marimo-pair-lens-images" ]] || return 1
-  rm -rf -- "$canonical_dir"
+  printf '%s\n' "$canonical_dir"
+}
+
+cleanup_image_dirs() {
+  local requested_dir canonical_dir image_dirs_json
+  local canonical_dirs=()
+
+  for requested_dir in "$@"; do
+    canonical_dir=$(canonical_image_dir "$requested_dir") || return 1
+    canonical_dirs+=("$canonical_dir")
+  done
+  for canonical_dir in "${canonical_dirs[@]}"; do
+    rm -rf -- "$canonical_dir"
+  done
+  image_dirs_json=$(jq -cn '$ARGS.positional' --args "${canonical_dirs[@]}")
   jq -cn \
-    --arg imageDir "$canonical_dir" \
-    '{action: "cleanup-images", result: {status: "removed", imageDir: $imageDir}}'
+    --argjson imageDirs "$image_dirs_json" \
+    '{
+      action: "cleanup-images",
+      result: {
+        status: "removed",
+        imageDirs: $imageDirs,
+        count: ($imageDirs | length)
+      }
+    }'
 }
 
 materialize_image() {
@@ -327,12 +360,139 @@ materialize_image() {
     ' <<<"$response"
 }
 
+capture_cell_image() {
+  local response="$1"
+  local token="$2"
+  local requested_cell_id="$3"
+  local status request_id read_args deadline
+
+  status=$(jq -r '.result.status // empty' <<<"$response")
+  if [[ "$status" != "pending" ]]; then
+    emit_response "$response" "image"
+    return
+  fi
+  request_id=$(jq -r '.result.requestId // empty' <<<"$response")
+  [[ -n "$request_id" ]] || {
+    echo "Lens did not return a capture request ID." >&2
+    return 1
+  }
+  read_args=$(jq -cn \
+    --arg requestId "$request_id" \
+    --arg lensToken "$token" \
+    '{requestId: $requestId, lensToken: $lensToken}')
+  deadline=$((SECONDS + 20))
+
+  while ((SECONDS < deadline)); do
+    response=$(invoke_action "output.capture.read" "$read_args")
+    status=$(jq -r '.result.status // empty' <<<"$response")
+    case "$status" in
+      pending)
+        sleep 0.25
+        ;;
+      available)
+        materialize_image "$response"
+        return
+        ;;
+      *)
+        emit_response "$response" "image"
+        return
+        ;;
+    esac
+  done
+
+  jq -cn \
+    --arg requestId "$request_id" \
+    --arg cellId "$requested_cell_id" \
+    '{
+      action: "image",
+      result: {
+        status: "capture-timeout",
+        requestId: $requestId,
+        cellId: $cellId
+      }
+    }'
+  return 1
+}
+
+image_from_scan() {
+  local response="$1"
+  local image_source="$2"
+  local token revision_value identifier image_args image_response
+
+  token=$(jq -r '.result.lensToken // empty' <<<"$response")
+  revision_value=$(jq -r '.result.revision // empty' <<<"$response")
+  if [[ "$image_source" == "selection" ]]; then
+    identifier=$(jq -r '.result.current.id // empty' <<<"$response")
+    if [[ -z "$identifier" ]]; then
+      jq -cn '{
+        action: "image",
+        result: {
+          status: "image-unavailable",
+          source: "selection",
+          error: "The Lens scan has no current selection."
+        }
+      }'
+      return 1
+    fi
+    image_args=$(jq -cn \
+      --arg selectionId "$identifier" \
+      --argjson revision "$revision_value" \
+      --arg lensToken "$token" \
+      '{selectionId: $selectionId, revision: $revision, lensToken: $lensToken}')
+    image_response=$(invoke_action "selection.image" "$image_args")
+    materialize_image "$image_response"
+    return
+  fi
+
+  identifier=$(jq -r '.result.current.outputCellId // empty' <<<"$response")
+  if [[ -z "$identifier" ]]; then
+    jq -cn '{
+      action: "image",
+      result: {
+        status: "image-unavailable",
+        source: "cell",
+        error: "The Lens scan has no current output cell."
+      }
+    }'
+    return 1
+  fi
+  image_args=$(jq -cn \
+    --arg cellId "$identifier" \
+    --argjson revision "$revision_value" \
+    --arg lensToken "$token" \
+    '{cellId: $cellId, revision: $revision, lensToken: $lensToken}')
+  image_response=$(invoke_action "output.capture.start" "$image_args")
+  capture_cell_image "$image_response" "$token" "$identifier"
+}
+
 if [[ "$command" == "cleanup-images" ]]; then
-  cleanup_image_dir "$image_dir" || {
-    echo "Refusing to remove an image directory not created by marimo-pair." >&2
+  cleanup_image_dirs "${positionals[@]}" || {
+    echo "Refusing to remove directories not created by marimo-pair." >&2
     exit 1
   }
   exit
+fi
+
+if [[ "$command" == "scan" ]]; then
+  response=$(invoke_action "$action" "$args_json")
+  if [[ -z "$scan_image" || "$(jq -r '.result.status // empty' <<<"$response")" != "ready" ]]; then
+    emit_response "$response" "scan"
+    exit
+  fi
+
+  image_exit=0
+  if image_response=$(image_from_scan "$response" "$scan_image"); then
+    image_exit=0
+  else
+    image_exit=$?
+  fi
+  image_result=$(jq -c '.result' <<<"$image_response")
+  jq -c \
+    --arg source "$scan_image" \
+    --argjson image "$image_result" \
+    '.result.image = ({source: $source} + $image)' \
+    <<<"$response"
+  exit "$image_exit"
 fi
 
 if [[ "$command" != "image" ]]; then
@@ -347,49 +507,4 @@ if [[ "$action" == "selection.image" ]]; then
   exit
 fi
 
-status=$(jq -r '.result.status // empty' <<<"$response")
-if [[ "$status" != "pending" ]]; then
-  emit_response "$response" "image"
-  exit
-fi
-request_id=$(jq -r '.result.requestId // empty' <<<"$response")
-[[ -n "$request_id" ]] || {
-  echo "Lens did not return a capture request ID." >&2
-  exit 1
-}
-read_args=$(jq -cn \
-  --arg requestId "$request_id" \
-  --arg lensToken "$lens_token" \
-  '{requestId: $requestId, lensToken: $lensToken}')
-deadline=$((SECONDS + 20))
-
-while ((SECONDS < deadline)); do
-  response=$(invoke_action "output.capture.read" "$read_args")
-  status=$(jq -r '.result.status // empty' <<<"$response")
-  case "$status" in
-    pending)
-      sleep 0.25
-      ;;
-    available)
-      materialize_image "$response"
-      exit
-      ;;
-    *)
-      emit_response "$response" "image"
-      exit
-      ;;
-  esac
-done
-
-jq -cn \
-  --arg requestId "$request_id" \
-  --arg cellId "$cell_id" \
-  '{
-    action: "image",
-    result: {
-      status: "capture-timeout",
-      requestId: $requestId,
-      cellId: $cellId
-    }
-  }'
-exit 1
+capture_cell_image "$response" "$lens_token" "$cell_id"


### PR DESCRIPTION
Adds optional marimo-lens support to Pair so users can point at notebook output and ask about "this" without copying context into chat.

When Lens is available, Pair reads the current selection, loads bounded text or a grouped cell image when needed, shows contextual progress, verifies the result, resolves related selections together, and reveals the finished cell. Pair follows its existing workflow when Lens is absent.