### PR TITLE
Rewrite the discovery and execution scripts; Fix WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@
 - A running [marimo](https://marimo.io) notebook (`--no-token` for
   auto-discovery; `MARIMO_TOKEN` env var for servers with auth)
 - `bash`, `curl`, and `jq` available on `PATH` (on Windows, run from
-  Git Bash)
+  Git Bash, or from WSL with those tools installed in the distro — the
+  scripts also find notebooks running on the Windows host)
 
 ## Install
 

--- a/skills/marimo-pair/SKILL.md
+++ b/skills/marimo-pair/SKILL.md
@@ -29,7 +29,8 @@ prefer `ctx.cells[...].code` for current cell code.
 Use the bundled script (`bash scripts/execute-code.sh`) or MCP
 (`execute_code(...)`) to run Python in a live marimo kernel.
 
-If the user provides a notebook URL, target it directly:
+`execute-code.sh` always takes `--url`. If the user provides a notebook URL,
+target it directly:
 
 ```bash
 bash scripts/execute-code.sh --url http://localhost:2718 -c "print('connected')"
@@ -54,10 +55,11 @@ When code already lives in a file, pass the file path:
 bash scripts/execute-code.sh --url http://localhost:2718 /tmp/code.py
 ```
 
-If no target is provided, find or start a session. First look for a running
-session with `bash scripts/discover-servers.sh`, MCP `list_sessions()`, or
-local process context. When multiple sessions are possible, target with
-`--url`, `--port`, or `--session`.
+If the user gives no URL, find or start a session. Look for a running server
+with `bash scripts/discover-servers.sh`, MCP `list_sessions()`, or local
+process context, and pass the `url` it reports to `--url`. The session is
+resolved for you unless several notebooks are open on that server, in which
+case add `--session`.
 
 If no server is running and the user wants a notebook, start marimo with
 `--no-token` (and without `--headless`) so it auto-registers for discovery. The

--- a/skills/marimo-pair/reference/execution-context.md
+++ b/skills/marimo-pair/reference/execution-context.md
@@ -9,19 +9,15 @@ incorrectly.
 - `--url` is required, and connects to a marimo server or notebook URL.
 - `--session` selects one notebook session on that server.
 
-`discover-servers.sh` reports a `url` for every server it finds, already
-resolved for wherever the script is running, plus `origin` (`local` or
-`windows-host`). Pass it to `--url` as given.
+`discover-servers.sh` reports a `url` for every server it finds, resolved for
+wherever the script is running, plus `origin` (`local` or `windows-host`). Pass
+it to `--url` as given. A `url` of `null` means the server is running but
+nothing answered on any address reachable.
 
-A `url` of `null` means the server is running but nothing answered on any
-address reachable from here. `discover-servers.sh` explains that case on
-stderr — see the WSL error below.
-
-The session is resolved automatically when the server has one notebook open,
-which is the usual case. Pass `--session` only when the script reports several.
-Do not hold on to a session id: marimo keeps one session per notebook file and
-renames it whenever the browser reconnects, so an id goes stale on a page
-refresh while the notebook and its kernel carry on. Re-read it when you need it.
+Sessions are resolved automatically when the server has one notebook open. Pass
+`--session` only when the script reports several. Session ids go stale on user
+page refresh, so be mindful of holding onto session ids for too long. Re-read
+it when you need it.
 
 If multiple servers or sessions are available, do not guess. Ask for the URL or
 session, or inspect local context.
@@ -55,7 +51,6 @@ bash scripts/execute-code.sh --url http://localhost:2718 /tmp/code.py
 
 ## Common Script Errors
 
-- **Missing --url** - run `discover-servers.sh` and pass the url it reports.
 - **`[]` from discover-servers.sh** - nothing is registered. Only servers
   started with `--no-token` register; otherwise ask the user for the URL, or
   start marimo with the project's normal tooling.

--- a/skills/marimo-pair/reference/execution-context.md
+++ b/skills/marimo-pair/reference/execution-context.md
@@ -6,11 +6,22 @@ incorrectly.
 
 ## Targeting
 
-Use explicit targets when possible.
+- `--url` is required, and connects to a marimo server or notebook URL.
+- `--session` selects one notebook session on that server.
 
-- `--url` connects to a known marimo server or notebook URL.
-- `--port` selects a local marimo server from the registry.
-- `--session` selects one notebook session on a server.
+`discover-servers.sh` reports a `url` for every server it finds, already
+resolved for wherever the script is running, plus `origin` (`local` or
+`windows-host`). Pass it to `--url` as given.
+
+A `url` of `null` means the server is running but nothing answered on any
+address reachable from here. `discover-servers.sh` explains that case on
+stderr — see the WSL error below.
+
+The session is resolved automatically when the server has one notebook open,
+which is the usual case. Pass `--session` only when the script reports several.
+Do not hold on to a session id: marimo keeps one session per notebook file and
+renames it whenever the browser reconnects, so an id goes stale on a page
+refresh while the notebook and its kernel carry on. Re-read it when you need it.
 
 If multiple servers or sessions are available, do not guess. Ask for the URL or
 session, or inspect local context.
@@ -44,14 +55,25 @@ bash scripts/execute-code.sh --url http://localhost:2718 /tmp/code.py
 
 ## Common Script Errors
 
-- **No running marimo instances found** - use an explicit `--url`, or start
-  marimo with the project's normal tooling.
-- **Multiple instances found** - rerun with `--port` or `--url`.
+- **Missing --url** - run `discover-servers.sh` and pass the url it reports.
+- **`[]` from discover-servers.sh** - nothing is registered. Only servers
+  started with `--no-token` register; otherwise ask the user for the URL, or
+  start marimo with the project's normal tooling.
 - **No active sessions on the server** - open the notebook in the browser or
   provide `--session`.
-- **Multiple sessions on server** - rerun with `--session`.
+- **Multiple sessions on server** - several notebooks are open; rerun with the
+  `--session` id shown next to the filename you want.
 - **Failed to connect** - check the URL, token, and whether the server is still
   running.
+- **Execution did not complete** - the server ended the stream without a
+  result. With `--session`, the id is probably stale after a page refresh;
+  retry without it.
+- **... is running on the Windows host but answered at no address reachable
+  from WSL** - WSL's network cannot reach it. The message lists the fixes; the
+  usual one is restarting marimo on the host with `--host 0.0.0.0`. Running the
+  scripts from Git Bash or PowerShell on the Windows side also works.
+- **needs jq / curl on PATH** - install them in whichever environment runs the
+  scripts. Inside WSL that means the distro, not Windows.
 - **SyntaxError** - the submitted Python was malformed; use a heredoc or file.
 - **ImportError** - diagnose in the notebook kernel. Install packages through
   `cm` when needed.

--- a/skills/marimo-pair/reference/finding-marimo.md
+++ b/skills/marimo-pair/reference/finding-marimo.md
@@ -28,7 +28,7 @@ which `discover-servers.sh` also reads. Windows-host servers show up with
 `"origin": "windows-host"`, and reaching them depends on WSL networking: under
 the default NAT the distro has its own loopback, so a host notebook bound to
 `127.0.0.1` is unreachable and only `--host 0.0.0.0` (or mirrored networking)
-lets WSL connect. The `url` in each entry already accounts for this — use it.
+lets WSL connect. The `url` in each entry already accounts for this, so use it.
 
 Cross-OS discovery needs WSL interop: `cmd.exe` to locate the Windows profile,
 and `tasklist.exe` to tell a live Windows PID from a dead one. With interop

--- a/skills/marimo-pair/reference/finding-marimo.md
+++ b/skills/marimo-pair/reference/finding-marimo.md
@@ -19,7 +19,7 @@ How you invoke `marimo` depends on context — find the right way to run it.
 ## Where the registry lives
 
 A registering server writes one JSON file per instance and removes it on clean
-shutdown: `$XDG_STATE_HOME/marimo/servers` (default `~/.local/state/marimo`)
+shutdown: `$XDG_STATE_HOME/marimo/servers` (default `~/.local/state/marimo/servers`)
 on Linux and macOS, `%USERPROFILE%\.marimo\servers` on Windows.
 
 Inside WSL, both are in play. A notebook started in the distro registers at the

--- a/skills/marimo-pair/reference/finding-marimo.md
+++ b/skills/marimo-pair/reference/finding-marimo.md
@@ -16,6 +16,24 @@ the local URL and wait for them to open it before executing code.
 
 How you invoke `marimo` depends on context — find the right way to run it.
 
+## Where the registry lives
+
+A registering server writes one JSON file per instance and removes it on clean
+shutdown: `$XDG_STATE_HOME/marimo/servers` (default `~/.local/state/marimo`)
+on Linux and macOS, `%USERPROFILE%\.marimo\servers` on Windows.
+
+Inside WSL, both are in play. A notebook started in the distro registers at the
+XDG path; one started on the Windows host registers in the Windows profile,
+which `discover-servers.sh` also reads. Windows-host servers show up with
+`"origin": "windows-host"`, and reaching them depends on WSL networking: under
+the default NAT the distro has its own loopback, so a host notebook bound to
+`127.0.0.1` is unreachable and only `--host 0.0.0.0` (or mirrored networking)
+lets WSL connect. The `url` in each entry already accounts for this — use it.
+
+Cross-OS discovery needs WSL interop: `cmd.exe` to locate the Windows profile,
+and `tasklist.exe` to tell a live Windows PID from a dead one. With interop
+disabled, only servers inside the distro are found.
+
 ## Notebooks with PEP 723 metadata require `--sandbox`
 
 Before picking a runner, check the notebook file for a PEP 723 header:

--- a/skills/marimo-pair/scripts/discover-servers.sh
+++ b/skills/marimo-pair/scripts/discover-servers.sh
@@ -1,54 +1,320 @@
 #!/usr/bin/env bash
 # List running marimo instances from the server registry.
-# Cleans up stale entries (dead PIDs) and outputs live servers as JSON.
+# Cleans up stale entries and outputs live servers as JSON.
 # No marimo installation required.
+#
+# Servers started with --no-token register themselves and deregister on clean
+# shutdown, so a leftover file means the process was killed hard. See
+# marimo/_server/server_registry.py.
+#
+# Prints one object per live server:
+#   server_id             marimo's name for it, e.g. "127.0.0.1:2718"
+#   origin                "local" or "windows-host", relative to us
+#   url                   base URL that answered from here, or null if none did
+#   started_at, version   passed through from the registry
+#
+# Pass `url` straight to execute-code.sh --url.
 set -euo pipefail
 
-# Locate the servers directory
-is_windows=false
-if [[ "$OSTYPE" == msys* || "$OSTYPE" == cygwin* ]]; then
-  is_windows=true
-  servers_dir="$HOME/.marimo/servers"
+missing=""
+for tool in jq curl; do
+  command -v "$tool" >/dev/null 2>&1 || missing="${missing:+$missing, }$tool"
+done
+if [[ -n "$missing" ]]; then
+  echo "discover-servers.sh needs ${missing} on PATH." >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------- platform ---
+
+if [[ "${OSTYPE:-}" == msys* || "${OSTYPE:-}" == cygwin* ]]; then
+  platform=windows
+elif [[ -n "${WSL_DISTRO_NAME:-}" ]] || grep -qi microsoft /proc/version 2>/dev/null; then
+  platform=wsl
 else
-  servers_dir="${XDG_STATE_HOME:-$HOME/.local/state}/marimo/servers"
+  platform=posix
 fi
 
-if [[ ! -d "$servers_dir" ]]; then
-  echo "[]"
-  exit 0
+# Path to a Windows executable. With appendWindowsPath=false interop still
+# works, it is just not on PATH.
+windows_exe() {
+  local name=$1 sys32
+  if command -v "$name" >/dev/null 2>&1; then
+    command -v "$name"
+    return 0
+  fi
+  command -v wslpath >/dev/null 2>&1 || return 1
+  sys32=$(wslpath -u 'C:\Windows\System32' 2>/dev/null) || return 1
+  [[ -x "$sys32/$name" ]] || return 1
+  printf '%s\n' "$sys32/$name"
+}
+
+# ------------------------------------------------------- registry locations ---
+#
+# Origin is tracked per directory, not guessed from an entry's path: a Linux box
+# may well keep its home under a mount point.
+
+dirs=()
+origins=()
+
+if [[ "$platform" == windows ]]; then
+  dirs+=("$HOME/.marimo/servers")
+else
+  dirs+=("${XDG_STATE_HOME:-$HOME/.local/state}/marimo/servers")
+fi
+origins+=("local")
+
+# From WSL, a notebook may also be running on the Windows host. Ask cmd.exe for
+# the profile rather than globbing /mnt for it.
+if [[ "$platform" == wsl ]] && cmd_exe=$(windows_exe cmd.exe); then
+  # cmd.exe warns on a UNC cwd but still prints the value.
+  profile=$("$cmd_exe" /c 'echo %USERPROFILE%' 2>/dev/null | tr -d '\r\n') || profile=""
+  if [[ -n "$profile" && "$profile" != "%USERPROFILE%" ]] && command -v wslpath >/dev/null 2>&1; then
+    win_home=$(wslpath -u "$profile" 2>/dev/null) || win_home=""
+    if [[ -n "$win_home" ]]; then
+      dirs+=("$win_home/.marimo/servers")
+      origins+=("windows-host")
+    fi
+  fi
 fi
 
-# Liveness check. On POSIX, `kill -0 $pid` is cheap and reliable. On Windows
-# (Git Bash/MSYS2) `kill` operates on Cygwin PIDs, not the native Windows PIDs
-# marimo writes, so fall back to an HTTP probe against marimo's /health.
-check_live() {
-  local f="$1"
-  if [[ "$is_windows" == false ]]; then
-    local pid
-    pid=$(jq -r '.pid' "$f" 2>/dev/null) || return 1
-    kill -0 "$pid" 2>/dev/null
+# ---------------------------------------------------------------- liveness ---
+#
+# A server is live if its process is running or something answers at its
+# address. Neither signal is reliable alone — Windows recycles PIDs, and a
+# healthy server can be unreachable across the WSL boundary — so an entry is
+# only deleted when both say it is gone.
+
+tasklist_csv=""
+tasklist_state=""
+
+load_tasklist() {
+  local exe
+  [[ -z "$tasklist_state" ]] || return 0
+  tasklist_state=fail
+  if exe=$(windows_exe tasklist.exe); then
+    # Git Bash would otherwise mangle /FO and /NH into paths.
+    tasklist_csv=$(MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' \
+      "$exe" /FO CSV /NH 2>/dev/null) || tasklist_csv=""
+  fi
+  # tasklist.exe exits 0 even when it only printed an error, so check the shape
+  # before trusting this to declare anything dead.
+  if grep -qE '^"[^"]*","[0-9]+",' <<<"$tasklist_csv"; then
+    tasklist_state=ok
   else
-    local host port base_url
-    host=$(jq -r '.host' "$f" 2>/dev/null) || return 1
-    port=$(jq -r '.port' "$f" 2>/dev/null) || return 1
-    base_url=$(jq -r '.base_url' "$f" 2>/dev/null) || return 1
-    curl -sf --max-time 1 "http://${host}:${port}${base_url}/health" >/dev/null 2>&1
+    tasklist_csv=""
   fi
 }
 
-results="[]"
-for f in "$servers_dir"/*.json; do
-  [[ -e "$f" ]] || continue
+# 0 = running, 1 = definitely gone, 2 = cannot tell
+process_alive() {
+  local pid=$1 origin=$2
+  [[ "$pid" =~ ^[0-9]+$ ]] || return 2
+  if [[ "$origin" == windows-host || "$platform" == windows ]]; then
+    # A POSIX kill cannot see a Windows PID, so ask Windows.
+    load_tasklist
+    [[ "$tasklist_state" == ok ]] || return 2
+    if grep -q "^\"[^\"]*\",\"${pid}\"," <<<"$tasklist_csv"; then
+      return 0
+    fi
+    return 1
+  fi
+  if kill -0 "$pid" 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
 
-  if ! check_live "$f"; then
-    # On Windows the HTTP probe can fail transiently (slow start, busy server),
-    # so keep the entry; only POSIX `kill -0` is reliable enough to delete on.
-    [[ "$is_windows" == false ]] && rm -f "$f"
-    continue
+# ------------------------------------------------------------ reachability ---
+
+gateway=""
+gateway_resolved=false
+
+# The default gateway, which under WSL NAT is the Windows host.
+find_gateway() {
+  local hex
+  [[ "$gateway_resolved" == false ]] || return 0
+  gateway_resolved=true
+  if command -v ip >/dev/null 2>&1; then
+    # `|| gateway=""` keeps `set -e` from killing us before the fallback runs.
+    gateway=$(ip route show default 2>/dev/null | awk 'NR == 1 { print $3 }') || gateway=""
+  fi
+  if [[ -z "$gateway" && -r /proc/net/route ]]; then
+    # Without iproute2, read the default route (destination and mask zero)
+    # from the kernel. Its gateway field is little-endian hex.
+    hex=$(awk '$2 == "00000000" && $8 == "00000000" { print $3; exit }' /proc/net/route 2>/dev/null) || hex=""
+    if [[ "$hex" =~ ^[0-9A-Fa-f]{8}$ ]]; then
+      printf -v gateway '%d.%d.%d.%d' \
+        "0x${hex:6:2}" "0x${hex:4:2}" "0x${hex:2:2}" "0x${hex:0:2}"
+    fi
+  fi
+}
+
+is_private_ipv4() {
+  case "$1" in
+    10.*|127.*|192.168.*|169.254.*) return 0 ;;
+    172.1[6-9].*|172.2[0-9].*|172.3[01].*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Check that a marimo answers here, not just any HTTP server — this is where
+# code and tokens get sent. /health needs no auth.
+answers_marimo() {
+  curl -sf --connect-timeout 1 --max-time 2 "$1/health" 2>/dev/null | grep -q '"healthy"'
+}
+
+local_port_taken() {
+  local i
+  for ((i = 0; i < live_count; i++)); do
+    if [[ "${live_origins[$i]}" == local && "${live_ports[$i]}" == "$1" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Addresses worth trying for one entry, best first.
+candidate_hosts() {
+  local host=$1 port=$2 origin=$3
+  if [[ "$origin" == local ]]; then
+    # A bind-all address is not a connect target; use loopback.
+    case "$host" in
+      0.0.0.0|"") echo 127.0.0.1 ;;
+      ::) echo ::1 ;;
+      *) echo "$host" ;;
+    esac
+    return 0
   fi
 
-  entry=$(jq '.' "$f" 2>/dev/null) || continue
-  results=$(echo "$results" | jq --argjson e "$entry" '. + [$e]')
+  # A Windows-host server is across the WSL boundary. A specific address names
+  # the machine and works from either side.
+  case "$host" in
+    0.0.0.0|::|127.0.0.1|localhost|::1|"") ;;
+    *) echo "$host" ;;
+  esac
+
+  find_gateway
+  if [[ -n "$gateway" ]] && is_private_ipv4 "$gateway"; then
+    echo "$gateway"
+  fi
+
+  # Loopback here is the distro's own, and only reaches the host under mirrored
+  # networking. Last resort, and skipped when a local server holds the port —
+  # that would be the wrong kernel. Local entries are scanned first.
+  case "$host" in
+    0.0.0.0|::|127.0.0.1|localhost|::1|"")
+      local_port_taken "$port" || echo 127.0.0.1
+      ;;
+  esac
+}
+
+# Print a base URL that answered, or nothing.
+resolve_url() {
+  local host=$1 port=$2 base_url=$3 origin=$4 candidate url
+  while IFS= read -r candidate; do
+    [[ -n "$candidate" ]] || continue
+    case "$candidate" in
+      *:*) url="http://[${candidate}]:${port}${base_url}" ;; # IPv6 literal
+      *) url="http://${candidate}:${port}${base_url}" ;;
+    esac
+    if answers_marimo "$url"; then
+      printf '%s' "$url"
+      return 0
+    fi
+  done <<<"$(candidate_hosts "$host" "$port" "$origin")"
+  return 1
+}
+
+# ------------------------------------------------------------------- scan ---
+
+live_files=()
+live_origins=()
+live_urls=()
+live_ids=()
+live_pids=()
+live_hosts=()
+live_ports=()
+live_count=0
+
+for ((i = 0; i < ${#dirs[@]}; i++)); do
+  dir=${dirs[$i]}
+  origin=${origins[$i]}
+  [[ -d "$dir" ]] || continue
+
+  for file in "$dir"/*.json; do
+    [[ -e "$file" ]] || continue
+
+    meta=$(jq -r '[(.server_id // ""), (.pid|tostring), (.host // ""), (.port|tostring), (.base_url // "")] | @tsv' "$file" 2>/dev/null) || continue
+    IFS=$'\t' read -r id pid host port base_url <<<"$meta"
+
+    state=0
+    process_alive "$pid" "$origin" || state=$?
+    url=$(resolve_url "$host" "$port" "$base_url" "$origin") || url=""
+
+    if [[ $state -ne 0 && -z "$url" ]]; then
+      # Nothing answered. Drop the entry only if the process is gone for
+      # certain; state 2 means we could not tell, so leave it alone.
+      if [[ $state -eq 1 ]]; then
+        rm -f "$file"
+      fi
+      continue
+    fi
+
+    live_files+=("$file")
+    live_origins+=("$origin")
+    live_urls+=("$url")
+    live_ids+=("$id")
+    live_pids+=("$pid")
+    live_hosts+=("$host")
+    live_ports+=("$port")
+    live_count=$((live_count + 1))
+  done
 done
 
-echo "$results" | jq .
+# ----------------------------------------------------------------- output ---
+
+entries=""
+for ((i = 0; i < live_count; i++)); do
+  entry=$(jq -c --arg origin "${live_origins[$i]}" --arg url "${live_urls[$i]}" \
+    '{server_id, started_at, version, origin: $origin,
+      url: (if $url == "" then null else $url end)}' \
+    "${live_files[$i]}" 2>/dev/null) || continue
+  entries="${entries}${entry}"$'\n'
+done
+
+if [[ -z "$entries" ]]; then
+  echo '[]'
+else
+  printf '%s' "$entries" | jq -s '.'
+fi
+
+# Explain any server that is running but answered nowhere. How it was bound and
+# which side of the WSL boundary it is on decide the advice.
+for ((i = 0; i < live_count; i++)); do
+  [[ -z "${live_urls[$i]}" ]] || continue
+  id=${live_ids[$i]}
+  pid=${live_pids[$i]}
+  host=${live_hosts[$i]}
+  port=${live_ports[$i]}
+
+  if [[ "${live_origins[$i]}" == windows-host ]]; then
+    find_gateway
+    echo "${id} is running on the Windows host (PID ${pid}) but answered at no address reachable from WSL." >&2
+    case "$host" in
+      0.0.0.0|::)
+        echo "It is bound to ${host}, so the Windows firewall is the likely cause. Options:" >&2
+        echo "  - allow inbound TCP ${port} on the 'vEthernet (WSL)' adapter${gateway:+ (gateway ${gateway})}" >&2
+        ;;
+      *)
+        echo "WSL's NAT network cannot reach a service bound to ${host} on the host. Options:" >&2
+        echo "  - restart marimo on the host with --host 0.0.0.0${gateway:+ (reachable from WSL at ${gateway})}" >&2
+        echo "  - or switch WSL to mirrored networking: add 'networkingMode=mirrored' under [wsl2] in %USERPROFILE%\\.wslconfig, then run 'wsl --shutdown'" >&2
+        ;;
+    esac
+    echo "  - or run these scripts from Git Bash / PowerShell on the Windows side" >&2
+  else
+    echo "${id} is registered (PID ${pid}) but nothing answers there." >&2
+  fi
+  echo "If marimo is no longer running, PID ${pid} may belong to an unrelated process that reused the id." >&2
+done

--- a/skills/marimo-pair/scripts/execute-code.sh
+++ b/skills/marimo-pair/scripts/execute-code.sh
@@ -71,14 +71,26 @@ fi
 base="${url%/}"
 
 # Warn when connecting to a non-local server (data exfiltration risk)
-url_host="${url#*://}"
-url_host="${url_host%%[:/]*}"
+url_authority="${url#*://}"
+url_authority="${url_authority%%/*}"
+case "$url_authority" in
+  \[*\]*)
+    url_host="${url_authority#\[}"
+    url_host="${url_host%%\]*}"
+    ;;
+  *)
+    url_host="${url_authority%%:*}"
+    ;;
+esac
 case "$url_host" in
   localhost|127.0.0.1|::1|0.0.0.0) ;;
   *)
     # Under WSL the gateway is the Windows host running this distro, not a
     # remote machine.
-    gateway=$(ip route show default 2>/dev/null | awk 'NR == 1 { print $3 }') || gateway=""
+    gateway=""
+    if command -v ip >/dev/null 2>&1; then
+      gateway=$(ip route show default 2>/dev/null | awk 'NR == 1 { print $3 }') || gateway=""
+    fi
     if [[ "$url_host" != "$gateway" ]]; then
       echo "Warning: connecting to non-local server '${url_host}'. Ensure this is trusted." >&2
     fi

--- a/skills/marimo-pair/scripts/execute-code.sh
+++ b/skills/marimo-pair/scripts/execute-code.sh
@@ -72,7 +72,9 @@ base="${url%/}"
 
 # Warn when connecting to a non-local server (data exfiltration risk)
 url_authority="${url#*://}"
-url_authority="${url_authority%%/*}"
+url_authority="${url_authority%%[/?#]*}"
+# Strip userinfo so this check uses the same effective host as curl.
+url_authority="${url_authority##*@}"
 case "$url_authority" in
   \[*\]*)
     url_host="${url_authority#\[}"
@@ -91,7 +93,7 @@ case "$url_host" in
     if command -v ip >/dev/null 2>&1; then
       gateway=$(ip route show default 2>/dev/null | awk 'NR == 1 { print $3 }') || gateway=""
     fi
-    if [[ "$url_host" != "$gateway" ]]; then
+    if [[ -z "$gateway" || "$url_host" != "$gateway" ]]; then
       echo "Warning: connecting to non-local server '${url_host}'. Ensure this is trusted." >&2
     fi
     ;;

--- a/skills/marimo-pair/scripts/execute-code.sh
+++ b/skills/marimo-pair/scripts/execute-code.sh
@@ -175,6 +175,7 @@ exit_code=0
 current_event=""
 done_received=false
 while IFS= read -r line && [[ "$done_received" == false ]]; do
+  line="${line%$'\r'}" # SSE permits CRLF; `read` strips only the LF
   case "$line" in
     event:*)
       current_event="${line#event: }"

--- a/skills/marimo-pair/scripts/execute-code.sh
+++ b/skills/marimo-pair/scripts/execute-code.sh
@@ -2,38 +2,52 @@
 # Execute code in a running marimo session's scratchpad.
 # No marimo installation required — talks directly to the HTTP API.
 # Usage:
-#   execute-code.sh [--port PORT] [--session ID] -c "code"   # inline code
-#   execute-code.sh [--port PORT] [--session ID] script.py    # code from file
-#   execute-code.sh [--port PORT] [--session ID] <<< "code"   # stdin (here-string)
-#   execute-code.sh [--port PORT] [--session ID] <<'EOF'       # stdin (heredoc)
+#   execute-code.sh --url URL [--session ID] -c "code"    # inline code
+#   execute-code.sh --url URL [--session ID] script.py    # code from file
+#   execute-code.sh --url URL [--session ID] <<< "code"   # stdin (here-string)
+#   execute-code.sh --url URL [--session ID] <<'EOF'      # stdin (heredoc)
 #     code
 #   EOF
-#   execute-code.sh --url URL [--session ID] -c "code"        # skip discovery, hit URL directly
+#
+# Find the URL with discover-servers.sh. With one notebook open on the server
+# the session is resolved automatically; --session picks one of several.
 #
 # Auth: set MARIMO_TOKEN env var (preferred) or pass --token TOKEN (visible in ps).
 set -euo pipefail
 
+usage() {
+  echo "Usage: execute-code.sh --url URL [--session ID] -c 'code'" >&2
+  echo "       execute-code.sh --url URL [--session ID] script.py" >&2
+  echo "       echo 'code' | execute-code.sh --url URL [--session ID]" >&2
+  echo "URL:   run discover-servers.sh; it reports the url to use." >&2
+  echo "Auth:  set MARIMO_TOKEN env var (preferred) or pass --token TOKEN" >&2
+  exit 1
+}
+
 # Optional eval logging: set EXECUTE_CODE_LOG to a file path to record each call
 if [[ -n "${EXECUTE_CODE_LOG:-}" ]]; then
-  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$EXECUTE_CODE_LOG"
+  date -u +%Y-%m-%dT%H:%M:%SZ >> "$EXECUTE_CODE_LOG"
 fi
 
-port=""
 code=""
 url=""
 token="${MARIMO_TOKEN:-}"
 session=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --port)    port="$2"; shift 2 ;;
     --url)     url="$2"; shift 2 ;;
     --token)   token="$2"; shift 2 ;;
     --session) session="$2"; shift 2 ;;
     -c)        code="$2"; shift 2 ;;
-    -*)      echo "Unknown option: $1" >&2; exit 1 ;;
+    -*)      echo "Unknown option: $1" >&2; usage ;;
     *)       break ;;
   esac
 done
+
+if [[ -z "$url" ]]; then
+  echo "Missing --url." >&2
+  usage
+fi
 
 if [[ -n "$code" ]]; then
   : # set via -c
@@ -42,99 +56,34 @@ elif [[ $# -gt 0 ]]; then
 elif [[ ! -t 0 ]]; then
   code=$(cat)
 else
-  echo "Usage: execute-code.sh [--port PORT | --url URL] -c 'code'" >&2
-  echo "       execute-code.sh [--port PORT | --url URL] script.py" >&2
-  echo "       echo 'code' | execute-code.sh [--port PORT | --url URL]" >&2
-  echo "Auth:  set MARIMO_TOKEN env var (preferred) or pass --token TOKEN" >&2
+  usage
+fi
+
+missing=""
+for tool in jq curl; do
+  command -v "$tool" >/dev/null 2>&1 || missing="${missing:+$missing, }$tool"
+done
+if [[ -n "$missing" ]]; then
+  echo "execute-code.sh needs ${missing} on PATH." >&2
   exit 1
 fi
 
-if [[ -n "$url" ]]; then
-  base="${url%/}"
-  # Warn when connecting to a non-local server (data exfiltration risk)
-  url_host="${url#*://}"
-  url_host="${url_host%%[:/]*}"
-  case "$url_host" in
-    localhost|127.0.0.1|::1|0.0.0.0) ;;
-    *) echo "Warning: connecting to non-local server '${url_host}'. Ensure this is trusted." >&2 ;;
-  esac
-else
-  # Locate the servers directory
-  is_windows=false
-  if [[ "$OSTYPE" == msys* || "$OSTYPE" == cygwin* ]]; then
-    is_windows=true
-    servers_dir="$HOME/.marimo/servers"
-  else
-    servers_dir="${XDG_STATE_HOME:-$HOME/.local/state}/marimo/servers"
-  fi
+base="${url%/}"
 
-  # Liveness check. On POSIX, `kill -0 $pid` is cheap and reliable. On Windows
-  # (Git Bash/MSYS2) `kill` operates on Cygwin PIDs, not the native Windows PIDs
-  # marimo writes, so fall back to an HTTP probe against marimo's /health.
-  check_live() {
-    local f="$1"
-    if [[ "$is_windows" == false ]]; then
-      local pid
-      pid=$(jq -r '.pid' "$f" 2>/dev/null) || return 1
-      kill -0 "$pid" 2>/dev/null
-    else
-      local host port base_url
-      host=$(jq -r '.host' "$f" 2>/dev/null) || return 1
-      port=$(jq -r '.port' "$f" 2>/dev/null) || return 1
-      base_url=$(jq -r '.base_url' "$f" 2>/dev/null) || return 1
-      curl -sf --max-time 1 "http://${host}:${port}${base_url}/health" >/dev/null 2>&1
+# Warn when connecting to a non-local server (data exfiltration risk)
+url_host="${url#*://}"
+url_host="${url_host%%[:/]*}"
+case "$url_host" in
+  localhost|127.0.0.1|::1|0.0.0.0) ;;
+  *)
+    # Under WSL the gateway is the Windows host running this distro, not a
+    # remote machine.
+    gateway=$(ip route show default 2>/dev/null | awk 'NR == 1 { print $3 }') || gateway=""
+    if [[ "$url_host" != "$gateway" ]]; then
+      echo "Warning: connecting to non-local server '${url_host}'. Ensure this is trusted." >&2
     fi
-  }
-
-  # Find a live registry entry
-  entry=""
-  count=0
-  for f in "$servers_dir"/*.json; do
-    [[ -e "$f" ]] || continue
-
-    if ! check_live "$f"; then
-      # On Windows the HTTP probe can fail transiently (slow start, busy server),
-      # so keep the entry; only POSIX `kill -0` is reliable enough to delete on.
-      [[ "$is_windows" == false ]] && rm -f "$f"
-      continue
-    fi
-
-    e=$(cat "$f")
-
-    if [[ -n "$port" ]]; then
-      e_port=$(echo "$e" | jq -r '.port')
-      if [[ "$e_port" == "$port" ]]; then
-        entry="$e"
-        count=1
-        break
-      fi
-      continue
-    fi
-
-    entry="$e"
-    count=$((count + 1))
-  done
-
-  if [[ $count -eq 0 ]]; then
-    echo "No running marimo instances found." >&2
-    exit 1
-  fi
-
-  if [[ $count -gt 1 ]]; then
-    echo "Multiple instances found. Use --port to specify:" >&2
-    for f in "$servers_dir"/*.json; do
-      [[ -e "$f" ]] || continue
-      check_live "$f" || continue
-      jq -r '.server_id' "$f" >&2
-    done
-    exit 1
-  fi
-
-  host=$(echo "$entry" | jq -r '.host')
-  e_port=$(echo "$entry" | jq -r '.port')
-  base_url=$(echo "$entry" | jq -r '.base_url')
-  base="http://${host}:${e_port}${base_url}"
-fi
+    ;;
+esac
 
 # Build optional auth header
 auth_args=()
@@ -146,27 +95,37 @@ fi
 if [[ -n "$session" ]]; then
   session_id="$session"
 else
-  sessions_resp=$(curl -sf "${auth_args[@]+"${auth_args[@]}"}" "${base}/api/sessions") || {
+  sessions_resp=$(curl -sf --connect-timeout 5 "${auth_args[@]+"${auth_args[@]}"}" "${base}/api/sessions") || {
     echo "Failed to connect to marimo server at ${base}" >&2
+    case "$base" in
+      *//127.0.0.1:*|*//localhost:*)
+        if [[ -n "${WSL_DISTRO_NAME:-}" ]] || grep -qi microsoft /proc/version 2>/dev/null; then
+          echo "Under WSL, 127.0.0.1 is the distro's own loopback, not the Windows host's." >&2
+          echo "Run discover-servers.sh and use the url it reports." >&2
+        fi
+        ;;
+    esac
     exit 1
   }
 
-  session_ids=$(echo "$sessions_resp" | jq -r 'keys[]')
+  session_ids=$(jq -r 'keys[]' <<<"$sessions_resp")
 
   if [[ -z "$session_ids" ]]; then
     echo "No active sessions on the server. Make sure a notebook is open in the browser." >&2
     exit 1
   fi
 
-  session_count=$(echo "$session_ids" | wc -l | tr -d ' ')
+  session_count=$(wc -l <<<"$session_ids" | tr -d ' ')
 
   if [[ $session_count -gt 1 ]]; then
+    # TODO: select by filename instead. An id is only good until the browser
+    # reconnects; the filename is stable. Needs an upstream change first.
     echo "Multiple sessions on server. Cannot auto-select:" >&2
-    echo "$sessions_resp" | jq -r 'to_entries[] | "\(.key)  \(.value.filename // "")"' >&2
+    jq -r 'to_entries[] | "\(.key)  \(.value.filename // "")"' <<<"$sessions_resp" >&2
     exit 1
   fi
 
-  session_id=$(echo "$session_ids" | head -1)
+  session_id=$(head -1 <<<"$session_ids")
 fi
 
 # Execute code via SSE stream
@@ -174,31 +133,39 @@ fi
 exit_code=0
 current_event=""
 done_received=false
-while IFS= read -r line && [[ "$done_received" == false ]]; do
+unparsed=""
+# An error body has no trailing newline, so keep what `read` got on its last,
+# failing call.
+while { IFS= read -r line || [[ -n "$line" ]]; } && [[ "$done_received" == false ]]; do
   line="${line%$'\r'}" # SSE permits CRLF; `read` strips only the LF
   case "$line" in
     event:*)
       current_event="${line#event: }"
       ;;
+    "") ;; # SSE record separator
     data:*)
       payload="${line#data: }"
       case "$current_event" in
         stdout)
-          echo "$payload" | jq -jr '.data'
+          jq -jr '.data' <<<"$payload"
           ;;
         stderr)
-          echo "$payload" | jq -jr '.data' >&2
+          jq -jr '.data' <<<"$payload" >&2
           ;;
         done)
-          if echo "$payload" | jq -e '.success == false' >/dev/null 2>&1; then
-            echo "$payload" | jq -r '.error.msg' >&2
+          # Carries the success bit and output only; errors arrived as stderr.
+          if jq -e '.success == false' >/dev/null 2>&1 <<<"$payload"; then
             exit_code=1
           else
-            echo "$payload" | jq -r '.output.data // empty'
+            jq -r '.output.data // empty' <<<"$payload"
           fi
           done_received=true
           ;;
       esac
+      ;;
+    *)
+      # Not SSE at all — an error body rather than a stream.
+      unparsed="${unparsed}${line}"$'\n'
       ;;
   esac
 done < <(curl -sN -X POST "${base}/api/kernel/execute" \
@@ -207,5 +174,22 @@ done < <(curl -sN -X POST "${base}/api/kernel/execute" \
   ${auth_args[@]+"${auth_args[@]}"} \
   -d "$(jq -n --arg c "$code" '{code: $c}')" \
 )
+
+if [[ "$done_received" == false ]]; then
+  # No `done` event means the code never ran; without this we would exit 0.
+  echo "Execution did not complete: the server ended the stream without a result." >&2
+  if [[ -n "$unparsed" ]]; then
+    detail=$(jq -r '.detail // empty' <<<"$unparsed" 2>/dev/null) || detail=""
+    if [[ -n "$detail" ]]; then
+      echo "$detail" >&2
+    else
+      printf '%s' "$unparsed" >&2
+    fi
+  fi
+  if [[ -n "$session" ]]; then
+    echo "The --session id may be stale: marimo renames a session when the browser reconnects. Retry without --session." >&2
+  fi
+  exit 1
+fi
 
 exit "$exit_code"


### PR DESCRIPTION
Closes #63
Closes #31 
Closes #43 

The scripts had grown two ways to name a server and two copies of the platform handling. This settles both.

A server is named by its URL. Selection was originally by `host` and `port`. `--url` came later and is strictly better since it survives being passed around, and it is the only thing that still means anything under WSL, where a notebook in the distro and one on the Windows host can both register as `127.0.0.1:2718` while answering at different addresses. So `--port` is gone, `--url` is required, and discovery reports a URL already resolved for wherever it ran.

Windows and WSL work now. Finding the registry, deciding whether a Windows PID is alive, and reaching a host notebook across NAT are three separate problems, and solving them is why discovery now lives in `discover-servers.sh` alone. `execute-code.sh` takes a URL and runs code, nothing else.

Both scripts check for `jq` and `curl` up front and name whichever is missing. That matters most under WSL, where they have to be installed in the distro.

Verified on Windows 11 and WSL2 against real marimo servers, including executing code in the Windows kernel from inside the distro. `--port` is removed rather than deprecated  since the skill and its docs ship together, so there is nothing to keep working.