### PR TITLE
Target notebooks by file in `execute-code.sh`

### DIFF
--- a/skills/marimo-pair/SKILL.md
+++ b/skills/marimo-pair/SKILL.md
@@ -36,11 +36,10 @@ target it directly:
 bash scripts/execute-code.sh --url http://localhost:2718 -c "print('connected')"
 ```
 
-Use `-c` only for short one-liners. For multiline code or code containing
-quotes, backticks, `$`, or braces, use a single-quoted heredoc:
+Pass code with `-c CODE`, `-` for stdin, or a file path:
 
 ```bash
-bash scripts/execute-code.sh --url http://localhost:2718 <<'PY'
+bash scripts/execute-code.sh --url http://localhost:2718 - <<'PY'
 import marimo._code_mode as cm
 
 async with cm.get_context() as ctx:
@@ -49,28 +48,22 @@ async with cm.get_context() as ctx:
 PY
 ```
 
-When code already lives in a file, pass the file path:
-
-```bash
-bash scripts/execute-code.sh --url http://localhost:2718 /tmp/code.py
-```
-
-If the user gives no URL, find or start a session. Look for a running server
+If the user gives no URL, find or start a notebook. Look for a running server
 with `bash scripts/discover-servers.sh`, MCP `list_sessions()`, or local
-process context, and pass the `url` it reports to `--url`. The session is
-resolved for you unless several notebooks are open on that server, in which
-case add `--session`.
+process context, and pass the `url` it reports to `--url`. With one notebook
+open, the script targets it automatically; with several, pass `--file` with
+the notebook's file key.
 
 If no server is running and the user wants a notebook, start marimo with
 `--no-token` (and without `--headless`) so it auto-registers for discovery. The
-notebook UI must be open before there is an active session for `execute-code`
-to target. The right way to invoke marimo depends on context (project tooling,
-global install, sandbox mode). If the notebook file contains a PEP 723 `#
+notebook UI must be open for `execute-code` to target it. The right invocation
+depends on context (project tooling, global install, sandbox mode). If the
+notebook file contains a PEP 723 `#
 /// script` header, it MUST be opened with `--sandbox` — otherwise marimo
 ignores the inline dependencies. See
 [finding-marimo.md](reference/finding-marimo.md) for the full decision tree and
-[execution-context.md](reference/execution-context.md) for scripts, MCP, and
-shell quoting.
+[execution-context.md](reference/execution-context.md) for selector resolution,
+scripts, MCP, and shell quoting.
 
 ## Scratchpad Scope
 

--- a/skills/marimo-pair/reference/execution-context.md
+++ b/skills/marimo-pair/reference/execution-context.md
@@ -6,21 +6,12 @@ incorrectly.
 
 ## Targeting
 
-- `--url` is required, and connects to a marimo server or notebook URL.
-- `--session` selects one notebook session on that server.
-
-`discover-servers.sh` reports a `url` for every server it finds, resolved for
-wherever the script is running, plus `origin` (`local` or `windows-host`). Pass
-it to `--url` as given. A `url` of `null` means the server is running but
-nothing answered on any address reachable.
-
-Sessions are resolved automatically when the server has one notebook open. Pass
-`--session` only when the script reports several. Session ids go stale on user
-page refresh, so be mindful of holding onto session ids for too long. Re-read
-it when you need it.
-
-If multiple servers or sessions are available, do not guess. Ask for the URL or
-session, or inspect local context.
+- Pass the discovered `--url` unchanged; `null` means no address was reachable.
+- With one open notebook, the script resolves its session.
+- Use `--file` for an exact, stable file key or path. It resolves the current
+  session on every call.
+- Use `--session` for an exact active session ID; it goes stale on reconnect.
+- The selectors are mutually exclusive. Preserve supplied values; never guess.
 
 ## Auth
 
@@ -34,13 +25,12 @@ MARIMO_TOKEN=... bash scripts/execute-code.sh --url http://localhost:2718 -c "1 
 present, `--token` overrides `MARIMO_TOKEN`. The script sends the token as
 `Authorization: Bearer ...` on session discovery and code execution requests.
 
-## Quoting
+## Code Input
 
-Use `-c` only for short one-liners. Use a single-quoted heredoc or file input
-for multiline code or shell-sensitive characters.
+Pass code with `-c CODE`, `-` for stdin, or a file path.
 
 ```bash
-bash scripts/execute-code.sh --url http://localhost:2718 <<'PY'
+bash scripts/execute-code.sh --url http://localhost:2718 - <<'PY'
 print(df.head())
 PY
 ```
@@ -54,15 +44,16 @@ bash scripts/execute-code.sh --url http://localhost:2718 /tmp/code.py
 - **`[]` from discover-servers.sh** - nothing is registered. Only servers
   started with `--no-token` register; otherwise ask the user for the URL, or
   start marimo with the project's normal tooling.
-- **No active sessions on the server** - open the notebook in the browser or
-  provide `--session`.
+- **No active sessions on the server** - open the notebook in the browser.
+- **No active session matches `--file`** - check the exact file key against the
+  available paths printed by the script.
 - **Multiple sessions on server** - several notebooks are open; rerun with the
-  `--session` id shown next to the filename you want.
+  `--file` path or `--session` ID shown for the notebook you want.
 - **Failed to connect** - check the URL, token, and whether the server is still
   running.
 - **Execution did not complete** - the server ended the stream without a
-  result. With `--session`, the id is probably stale after a page refresh;
-  retry without it.
+  result. With `--file`, retry the same command so it resolves the current
+  session. With `--session`, the ID is probably stale after a page refresh.
 - **... is running on the Windows host but answered at no address reachable
   from WSL** - WSL's network cannot reach it. The message lists the fixes; the
   usual one is restarting marimo on the host with `--host 0.0.0.0`. Running the

--- a/skills/marimo-pair/reference/execution-context.md
+++ b/skills/marimo-pair/reference/execution-context.md
@@ -23,7 +23,7 @@ MARIMO_TOKEN=... bash scripts/execute-code.sh --url http://localhost:2718 -c "1 
 
 `--token` also works, but may expose the token in process listings. If both are
 present, `--token` overrides `MARIMO_TOKEN`. The script sends the token as
-`Authorization: Bearer ...` on session discovery and code execution requests.
+`Authorization: ******` on session discovery and code execution requests.
 
 ## Code Input
 

--- a/skills/marimo-pair/scripts/execute-code.sh
+++ b/skills/marimo-pair/scripts/execute-code.sh
@@ -2,23 +2,21 @@
 # Execute code in a running marimo session's scratchpad.
 # No marimo installation required — talks directly to the HTTP API.
 # Usage:
-#   execute-code.sh --url URL [--session ID] -c "code"    # inline code
-#   execute-code.sh --url URL [--session ID] script.py    # code from file
-#   execute-code.sh --url URL [--session ID] <<< "code"   # stdin (here-string)
-#   execute-code.sh --url URL [--session ID] <<'EOF'      # stdin (heredoc)
-#     code
-#   EOF
+#   execute-code.sh --url URL [--file PATH | --session ID] -c "code"
+#   execute-code.sh --url URL [--file PATH | --session ID] -
+#   execute-code.sh --url URL [--file PATH | --session ID] script.py
 #
 # Find the URL with discover-servers.sh. With one notebook open on the server
-# the session is resolved automatically; --session picks one of several.
+# the session is resolved automatically. --file stably identifies a notebook;
+# --session targets an exact (but ephemeral) session ID.
 #
 # Auth: set MARIMO_TOKEN env var (preferred) or pass --token TOKEN (visible in ps).
 set -euo pipefail
 
 usage() {
-  echo "Usage: execute-code.sh --url URL [--session ID] -c 'code'" >&2
-  echo "       execute-code.sh --url URL [--session ID] script.py" >&2
-  echo "       echo 'code' | execute-code.sh --url URL [--session ID]" >&2
+  echo "Usage: execute-code.sh --url URL [--file PATH | --session ID] -c 'code'" >&2
+  echo "       execute-code.sh --url URL [--file PATH | --session ID] -" >&2
+  echo "       execute-code.sh --url URL [--file PATH | --session ID] script.py" >&2
   echo "URL:   run discover-servers.sh; it reports the url to use." >&2
   echo "Auth:  set MARIMO_TOKEN env var (preferred) or pass --token TOKEN" >&2
   exit 1
@@ -33,12 +31,15 @@ code=""
 url=""
 token="${MARIMO_TOKEN:-}"
 session=""
+file=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --url)     url="$2"; shift 2 ;;
     --token)   token="$2"; shift 2 ;;
     --session) session="$2"; shift 2 ;;
+    --file)    file="$2"; shift 2 ;;
     -c)        code="$2"; shift 2 ;;
+    -)         break ;;
     -*)      echo "Unknown option: $1" >&2; usage ;;
     *)       break ;;
   esac
@@ -49,10 +50,19 @@ if [[ -z "$url" ]]; then
   usage
 fi
 
+if [[ -n "$session" && -n "$file" ]]; then
+  echo "--file and --session are mutually exclusive." >&2
+  usage
+fi
+
 if [[ -n "$code" ]]; then
   : # set via -c
 elif [[ $# -gt 0 ]]; then
-  code=$(cat "$1")
+  if [[ "$1" == "-" ]]; then
+    code=$(cat)
+  else
+    code=$(cat "$1")
+  fi
 elif [[ ! -t 0 ]]; then
   code=$(cat)
 else
@@ -105,7 +115,8 @@ if [[ -n "$token" ]]; then
   auth_args+=(-H "Authorization: Bearer ${token}")
 fi
 
-# Discover session ID
+# Resolve session ID. A file key is stable across browser reconnects, while a
+# session ID names one particular browser/kernel connection.
 if [[ -n "$session" ]]; then
   session_id="$session"
 else
@@ -129,17 +140,42 @@ else
     exit 1
   fi
 
-  session_count=$(wc -l <<<"$session_ids" | tr -d ' ')
+  if [[ -n "$file" ]]; then
+    matching_session_ids=$(jq -r --arg file "$file" '
+      to_entries[]
+      | select(.value.path == $file or .value.filename == $file)
+      | .key
+    ' <<<"$sessions_resp")
 
-  if [[ $session_count -gt 1 ]]; then
-    # TODO: select by filename instead. An id is only good until the browser
-    # reconnects; the filename is stable. Needs an upstream change first.
-    echo "Multiple sessions on server. Cannot auto-select:" >&2
-    jq -r 'to_entries[] | "\(.key)  \(.value.filename // "")"' <<<"$sessions_resp" >&2
-    exit 1
+    if [[ -z "$matching_session_ids" ]]; then
+      echo "No active session matches --file '${file}'. Available sessions:" >&2
+      jq -r 'to_entries[] | "\(.key)  \(.value.path // .value.filename // "")"' <<<"$sessions_resp" >&2
+      exit 1
+    fi
+
+    matching_session_count=$(wc -l <<<"$matching_session_ids" | tr -d ' ')
+    if [[ $matching_session_count -gt 1 ]]; then
+      echo "Multiple active sessions match --file '${file}':" >&2
+      jq -r --arg file "$file" '
+        to_entries[]
+        | select(.value.path == $file or .value.filename == $file)
+        | "\(.key)  \(.value.path // .value.filename // "")"
+      ' <<<"$sessions_resp" >&2
+      exit 1
+    fi
+
+    session_id=$(head -1 <<<"$matching_session_ids")
+  else
+    session_count=$(wc -l <<<"$session_ids" | tr -d ' ')
+
+    if [[ $session_count -gt 1 ]]; then
+      echo "Multiple sessions on server. Select one with --file or --session:" >&2
+      jq -r 'to_entries[] | "\(.key)  \(.value.path // .value.filename // "")"' <<<"$sessions_resp" >&2
+      exit 1
+    fi
+
+    session_id=$(head -1 <<<"$session_ids")
   fi
-
-  session_id=$(head -1 <<<"$session_ids")
 fi
 
 # Execute code via SSE stream
@@ -200,7 +236,9 @@ if [[ "$done_received" == false ]]; then
       printf '%s' "$unparsed" >&2
     fi
   fi
-  if [[ -n "$session" ]]; then
+  if [[ -n "$file" ]]; then
+    echo "The session for --file may have changed during execution. Retry the same --file command." >&2
+  elif [[ -n "$session" ]]; then
     echo "The --session id may be stale: marimo renames a session when the browser reconnects. Retry without --session." >&2
   fi
   exit 1


### PR DESCRIPTION
Resolve `--file` against the server's active sessions before execution while retaining `--session` for exact session targeting. Document file keys as the primary notebook selector and accept Python-style -c, stdin, and file inputs.

Supports both `--session` and `--file`, so don't need to wait on upstream release with `--file` prompt.
